### PR TITLE
feat(storage): implement per-function storage support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Never touch contents inside `<!-- automd -->` in README.md. They are auto genera
 - Returned cached function has `.resolveKeys(...args)` and `.invalidate(...args)` methods
 - `resolveCacheKeys({ options, args })` — standalone helper to resolve storage keys
 - `invalidateCache({ options, args })` — standalone helper to remove cached entries across all base prefixes
-- Uses `StorageInterface` via `useStorage()` for persistence
+- Uses `StorageInterface` via `opts.storage` (per-function) or `useStorage()` (global fallback) for persistence
 - Supports `waitUntil` on `event.req` (srvx/Cloudflare ServerRequest pattern) for background cache writes
 
 ### HTTP handler caching (`http.ts`)
@@ -45,13 +45,14 @@ Never touch contents inside `<!-- automd -->` in README.md. They are auto genera
 - Setting a nullish value (`null`/`undefined`) via `set` deletes the entry instead of storing dead weight
 - `createMemoryStorage()` — in-memory Map-based implementation with TTL expiry
 - `useStorage()` / `setStorage()` — global singleton, lazy-inits to memory storage
+- Per-function storage: pass `storage` in `CacheOptions` to override the global singleton for a specific cached function/handler; `opts.storage` takes precedence over `useStorage()`
 
 ### Types (`types.ts`)
 
 - `HTTPEvent` — `{ req: Request; url?: URL }` (url falls back to `new URL(req.url)`)
 - `EventHandler<E>` — `(event: E) => unknown | Promise<unknown>` (generic, defaults to HTTPEvent)
 - `CacheEntry<T>` — stored cache entry with value, expires, mtime, integrity
-- `CacheOptions<T>` — maxAge, swr, staleMaxAge, base (string | string[] for multi-tier), getKey, validate, transform, etc.
+- `CacheOptions<T>` — maxAge, swr, staleMaxAge, base (string | string[] for multi-tier), getKey, validate, transform, storage (per-function StorageInterface), etc.
 - `CachedEventHandlerOptions<E>` — extends CacheOptions with headersOnly, varies, toResponse, createResponse, handleCacheHeaders
 - `CacheConditions` — `{ modifiedTime?, maxAge?, etag? }` passed to handleCacheHeaders hook
 - `ResponseCacheEntry` — serialized response (status, statusText, headers, body)
@@ -74,4 +75,4 @@ Never touch contents inside `<!-- automd -->` in README.md. They are auto genera
 - Storage methods are `get`/`set` (not `getItem`/`setItem`)
 - `base` supports `string | string[]` — multi-tier: reads try each prefix in order (first hit wins), writes go to all prefixes
 - Default cache key group is `"functions"` (cache.ts) / `"handlers"` (http.ts) — no `ocache/` prefix
-- Integrity hash excludes `base`, `group`, `name` (storage-location fields) so entries remain valid across different base configurations
+- Integrity hash excludes `base`, `group`, `name`, `storage` (storage-location fields) so entries remain valid across different storage configurations

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ const cached = defineCachedFunction(fn, {
   validate: (entry) => entry.value !== undefined, // Custom validation
   transform: (entry) => entry.value, // Transform before returning
   onError: (error) => console.error(error), // Error handler
+  storage: myStorage, // Per-function storage (falls back to global setStorage())
 });
 ```
 
@@ -147,10 +148,9 @@ This is useful for layered cache setups (e.g., fast local cache + shared remote 
 
 ### Custom Storage
 
-By default, ocache uses an in-memory `Map`-based storage. You can provide a custom storage implementation:
+By default, ocache uses an in-memory `Map`-based storage. You can provide a custom storage implementation via `StorageInterface`:
 
 ```ts
-import { setStorage } from "ocache";
 import type { StorageInterface } from "ocache";
 
 const redisStorage: StorageInterface = {
@@ -166,9 +166,30 @@ const redisStorage: StorageInterface = {
     await redis.set(key, JSON.stringify(value), opts?.ttl ? { EX: opts.ttl } : undefined);
   },
 };
+```
+
+#### Global storage
+
+Use `setStorage` to set a storage backend for all cached functions at once:
+
+```ts
+import { setStorage } from "ocache";
 
 setStorage(redisStorage);
 ```
+
+#### Per-function storage
+
+Pass a `storage` option directly to `defineCachedFunction` or `defineCachedHandler` to use a different backend for a specific function:
+
+```ts
+const cachedFetch = defineCachedFunction(fetchData, {
+  maxAge: 60,
+  storage: redisStorage,
+});
+```
+
+This takes precedence over the global storage.
 
 ## API
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -42,7 +42,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
   const name = opts.name || fn.name || "_";
   const integrity = opts.integrity || hash([fn, _integrityOpts(opts)]);
   const validate = opts.validate || ((entry) => entry.value !== undefined);
-  const storage = opts.storage ?? useStorage();
+  const getStorage = () => opts.storage ?? useStorage();
   const _onError = (context: string, error: unknown) => {
     if (opts.onError) {
       opts.onError(error);
@@ -66,7 +66,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
     try {
       // Multi-tier read: try each base prefix in order, use first hit
       for (let i = 0; i < bases.length; i++) {
-        const result = (await storage.get(
+        const result = (await getStorage().get(
           _buildCacheKey(key, { group, name }, bases[i]!),
         )) as CacheEntry<T> | null;
         if (result) {
@@ -135,7 +135,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
         if (!isPending) {
           delete pending[key];
           // Evict stale entry from storage so SWR doesn't keep serving it
-          _evictFromStorage(key, bases, group, name, storage);
+          _evictFromStorage(key, bases, group, name, getStorage());
         }
         // Re-throw error to make sure the caller knows the task failed.
         throw error;
@@ -167,7 +167,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
             try {
               await Promise.all(
                 writeBases.map((b) =>
-                  storage.set(_buildCacheKey(key, { group, name }, b), entry, setOpts),
+                  getStorage().set(_buildCacheKey(key, { group, name }, b), entry, setOpts),
                 ),
               );
             } catch (error) {
@@ -179,7 +179,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
           }
         } else {
           // Revalidation produced an invalid result — evict stale entry from storage
-          _evictFromStorage(key, bases, group, name, storage);
+          _evictFromStorage(key, bases, group, name, getStorage());
         }
       }
     };

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,5 +1,5 @@
 import { hash } from "ohash";
-import { useStorage } from "./storage.ts";
+import { useStorage, type StorageInterface } from "./storage.ts";
 
 import type { HTTPEvent, CacheEntry, CacheOptions } from "./types.ts";
 
@@ -42,6 +42,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
   const name = opts.name || fn.name || "_";
   const integrity = opts.integrity || hash([fn, _integrityOpts(opts)]);
   const validate = opts.validate || ((entry) => entry.value !== undefined);
+  const storage = opts.storage ?? useStorage();
   const _onError = (context: string, error: unknown) => {
     if (opts.onError) {
       opts.onError(error);
@@ -65,7 +66,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
     try {
       // Multi-tier read: try each base prefix in order, use first hit
       for (let i = 0; i < bases.length; i++) {
-        const result = (await useStorage().get(
+        const result = (await storage.get(
           _buildCacheKey(key, { group, name }, bases[i]!),
         )) as CacheEntry<T> | null;
         if (result) {
@@ -134,7 +135,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
         if (!isPending) {
           delete pending[key];
           // Evict stale entry from storage so SWR doesn't keep serving it
-          _evictFromStorage(key, bases, group, name);
+          _evictFromStorage(key, bases, group, name, storage);
         }
         // Re-throw error to make sure the caller knows the task failed.
         throw error;
@@ -166,7 +167,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
             try {
               await Promise.all(
                 writeBases.map((b) =>
-                  useStorage().set(_buildCacheKey(key, { group, name }, b), entry, setOpts),
+                  storage.set(_buildCacheKey(key, { group, name }, b), entry, setOpts),
                 ),
               );
             } catch (error) {
@@ -178,7 +179,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
           }
         } else {
           // Revalidation produced an invalid result — evict stale entry from storage
-          _evictFromStorage(key, bases, group, name);
+          _evictFromStorage(key, bases, group, name, storage);
         }
       }
     };
@@ -286,12 +287,12 @@ export async function resolveCacheKeys<ArgsT extends unknown[] = any[]>(
  */
 export async function invalidateCache<ArgsT extends unknown[] = any[]>(
   input: {
-    options?: Pick<CacheOptions<any, ArgsT>, "base" | "group" | "name" | "getKey">;
+    options?: Pick<CacheOptions<any, ArgsT>, "base" | "group" | "name" | "getKey" | "storage">;
     args?: ArgsT;
   } = {},
 ): Promise<void> {
   const keys = await resolveCacheKeys(input);
-  const storage = useStorage();
+  const storage = input.options?.storage ?? useStorage();
   await Promise.all(keys.map((key) => storage.set(key, null)));
 }
 
@@ -320,14 +321,14 @@ function _normalizeBases(base: CacheOptions["base"]): [string, ...string[]] {
   return [base ?? "/cache"];
 }
 
-function _evictFromStorage(key: string, bases: string[], group: string, name: string) {
+function _evictFromStorage(key: string, bases: string[], group: string, name: string, storage: StorageInterface) {
   for (const b of bases) {
-    useStorage().set(_buildCacheKey(key, { group, name }, b), null);
+    storage.set(_buildCacheKey(key, { group, name }, b), null);
   }
 }
 
 /** Strips storage-location fields from opts so integrity only reflects the cached computation. */
-function _integrityOpts(opts: CacheOptions): Omit<CacheOptions, "base" | "group" | "name"> {
-  const { base: _, group: _g, name: _n, ...rest } = opts;
+function _integrityOpts(opts: CacheOptions): Omit<CacheOptions, "base" | "group" | "name" | "storage"> {
+  const { base: _, group: _g, name: _n, storage: _s, ...rest } = opts;
   return rest;
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -321,14 +321,22 @@ function _normalizeBases(base: CacheOptions["base"]): [string, ...string[]] {
   return [base ?? "/cache"];
 }
 
-function _evictFromStorage(key: string, bases: string[], group: string, name: string, storage: StorageInterface) {
+function _evictFromStorage(
+  key: string,
+  bases: string[],
+  group: string,
+  name: string,
+  storage: StorageInterface,
+) {
   for (const b of bases) {
     storage.set(_buildCacheKey(key, { group, name }, b), null);
   }
 }
 
 /** Strips storage-location fields from opts so integrity only reflects the cached computation. */
-function _integrityOpts(opts: CacheOptions): Omit<CacheOptions, "base" | "group" | "name" | "storage"> {
+function _integrityOpts(
+  opts: CacheOptions,
+): Omit<CacheOptions, "base" | "group" | "name" | "storage"> {
   const { base: _, group: _g, name: _n, storage: _s, ...rest } = opts;
   return rest;
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -205,8 +205,8 @@ function escapeKey(key: string | string[]) {
 /** Strips storage-location fields from opts so integrity only reflects the cached computation. */
 function _integrityOpts<E extends HTTPEvent>(
   opts: CachedEventHandlerOptions<E>,
-): Omit<CachedEventHandlerOptions<E>, "base" | "group" | "name"> {
-  const { base: _, group: _g, name: _n, ...rest } = opts;
+): Omit<CachedEventHandlerOptions<E>, "base" | "group" | "name" | "storage"> {
+  const { base: _, group: _g, name: _n, storage: _s, ...rest } = opts;
   return rest;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { StorageInterface } from "./storage.ts";
+
 /**
  * Extended `Request` interface with optional `waitUntil` for background tasks.
  *
@@ -68,6 +70,8 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
   base?: string | string[];
   /** Optional error handler called for all cache-related errors (read, write, SWR, malformed data). */
   onError?: (error: unknown) => void;
+  /** Custom storage backend for this cached function. Falls back to the global storage (`useStorage()`) when not provided. */
+  storage?: StorageInterface;
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1542,3 +1542,85 @@ describe("multi-tier base", () => {
     expect(callCount).toBe(0);
   });
 });
+
+describe("per-function storage", () => {
+  it("isolates two functions with different storage instances", async () => {
+    const s1 = createMemoryStorage();
+    const s2 = createMemoryStorage();
+    let count = 0;
+    const fn1 = defineCachedFunction(() => ++count, { maxAge: 60, name: "iso", getKey: () => "k", storage: s1 });
+    const fn2 = defineCachedFunction(() => ++count, { maxAge: 60, name: "iso", getKey: () => "k", storage: s2 });
+
+    expect(await fn1()).toBe(1);
+    // s2 is empty — does not find s1's cached value
+    expect(await fn2()).toBe(2);
+    // Both should now be cached in their own stores
+    expect(await fn1()).toBe(1);
+    expect(await fn2()).toBe(2);
+  });
+
+  it("fn.invalidate() targets per-function storage", async () => {
+    const custom = createMemoryStorage();
+    let count = 0;
+    const fn = defineCachedFunction(() => ++count, {
+      maxAge: 60,
+      swr: false,
+      getKey: () => "k",
+      storage: custom,
+    });
+
+    expect(await fn()).toBe(1);
+    await fn.invalidate();
+    expect(await fn()).toBe(2);
+  });
+
+  it("standalone invalidateCache uses options.storage", async () => {
+    const custom = createMemoryStorage();
+    let count = 0;
+    const opts = { maxAge: 60, swr: false, name: "inv", getKey: () => "k", storage: custom } as const;
+    const fn = defineCachedFunction(() => ++count, opts);
+
+    expect(await fn()).toBe(1);
+    await invalidateCache({ options: opts });
+    expect(await fn()).toBe(2);
+  });
+
+  it("per-function storage does not write to global storage", async () => {
+    const custom = createMemoryStorage();
+    const globalGet = vi.fn().mockReturnValue(null);
+    const globalSet = vi.fn();
+    setStorage({ get: globalGet, set: globalSet });
+
+    const fn = defineCachedFunction(() => "v", { maxAge: 60, storage: custom });
+    await fn();
+
+    expect(globalGet).not.toHaveBeenCalled();
+    expect(globalSet).not.toHaveBeenCalled();
+  });
+
+  it("defineCachedHandler propagates storage option", async () => {
+    const custom = createMemoryStorage();
+    let callCount = 0;
+    const handler = defineCachedHandler(
+      () => {
+        callCount++;
+        return new Response("ok");
+      },
+      { maxAge: 60, storage: custom },
+    );
+
+    const event = { req: new Request("http://localhost/storage-test") };
+    await handler(event);
+    await handler(event);
+
+    expect(callCount).toBe(1);
+
+    // Global storage was not touched
+    const keys = await resolveCacheKeys({
+      options: { name: "_", group: "handlers", base: "/cache" },
+    });
+    for (const key of keys) {
+      expect(await useStorage().get(key)).toBeNull();
+    }
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1548,8 +1548,18 @@ describe("per-function storage", () => {
     const s1 = createMemoryStorage();
     const s2 = createMemoryStorage();
     let count = 0;
-    const fn1 = defineCachedFunction(() => ++count, { maxAge: 60, name: "iso", getKey: () => "k", storage: s1 });
-    const fn2 = defineCachedFunction(() => ++count, { maxAge: 60, name: "iso", getKey: () => "k", storage: s2 });
+    const fn1 = defineCachedFunction(() => ++count, {
+      maxAge: 60,
+      name: "iso",
+      getKey: () => "k",
+      storage: s1,
+    });
+    const fn2 = defineCachedFunction(() => ++count, {
+      maxAge: 60,
+      name: "iso",
+      getKey: () => "k",
+      storage: s2,
+    });
 
     expect(await fn1()).toBe(1);
     // s2 is empty — does not find s1's cached value
@@ -1577,7 +1587,13 @@ describe("per-function storage", () => {
   it("standalone invalidateCache uses options.storage", async () => {
     const custom = createMemoryStorage();
     let count = 0;
-    const opts = { maxAge: 60, swr: false, name: "inv", getKey: () => "k", storage: custom } as const;
+    const opts = {
+      maxAge: 60,
+      swr: false,
+      name: "inv",
+      getKey: () => "k",
+      storage: custom,
+    } as const;
     const fn = defineCachedFunction(() => ++count, opts);
 
     expect(await fn()).toBe(1);


### PR DESCRIPTION

- Add `storage?: StorageInterface` to `CacheOptions` (and by extension `CachedEventHandlerOptions`) so each cached function/handler can use its own storage backend
- Falls back to the global `useStorage()` singleton when not provided — no breaking changes
- `fn.invalidate()` and standalone `invalidateCache()` both respect the per-function storage
- `storage` is excluded from the integrity hash so different storage instances don't cause spurious cache invalidation

## Usage

```ts
const redis = createRedisStorage(...)

const fn = defineCachedFunction(fetchUser, {
  maxAge: 60,
  storage: redis,
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-function storage configuration, enabling each cached function to use custom storage backends independently of global storage.

* **Tests**
  * Added comprehensive test coverage for per-function storage isolation and invalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->