### PR TITLE
fix(cache): handle eviction promise rejections and use waitUntil

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Never touch contents inside `<!-- automd -->` in README.md. They are auto genera
 ## Design Decisions
 
 - No h3/srvx/unstorage dependency — fully standalone
-- `waitUntil` accessed via `(event.req as any).waitUntil` — runtime-specific (srvx ServerRequest, Cloudflare), not typed on `Request`
+- `waitUntil` is typed as optional on `ServerRequest` (`event.req`) — runtime-specific (srvx ServerRequest, Cloudflare), accessed via `event?.req.waitUntil?.(promise)`
 - `event.url` is optional — `http.ts` falls back to `new URL(event.req.url)`
 - Storage methods are `get`/`set` (not `getItem`/`setItem`)
 - `base` supports `string | string[]` — multi-tier: reads try each prefix in order (first hit wins), writes go to all prefixes

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -134,7 +134,12 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
         if (!isPending) {
           delete pending[key];
           // Evict stale entry from storage so SWR doesn't keep serving it
-          _evictFromStorage(key, bases, group, name);
+          const evictPromise = _evictFromStorage(key, bases, group, name).catch((error) => {
+            _onError("[cache] Cache eviction error.", error);
+          });
+          if (event?.req?.waitUntil) {
+            event.req.waitUntil(evictPromise);
+          }
         }
         // Re-throw error to make sure the caller knows the task failed.
         throw error;
@@ -173,12 +178,17 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
               _onError("[cache] Cache write error.", error);
             }
           })();
-          if ((event?.req as any)?.waitUntil) {
-            (event!.req as any).waitUntil(promise);
+          if (event?.req?.waitUntil) {
+            event.req.waitUntil(promise);
           }
         } else {
           // Revalidation produced an invalid result — evict stale entry from storage
-          _evictFromStorage(key, bases, group, name);
+          const evictPromise = _evictFromStorage(key, bases, group, name).catch((error) => {
+            _onError("[cache] Cache eviction error.", error);
+          });
+          if (event?.req?.waitUntil) {
+            event.req.waitUntil(evictPromise);
+          }
         }
       }
     };
@@ -187,8 +197,8 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
 
     if (entry.value === undefined) {
       await _resolvePromise;
-    } else if (expired && (event?.req as any)?.waitUntil) {
-      (event!.req as any).waitUntil(_resolvePromise);
+    } else if (expired && event?.req?.waitUntil) {
+      event.req.waitUntil(_resolvePromise);
     }
 
     if (opts.swr && validate(entry) !== false) {
@@ -321,9 +331,9 @@ function _normalizeBases(base: CacheOptions["base"]): [string, ...string[]] {
 }
 
 function _evictFromStorage(key: string, bases: string[], group: string, name: string) {
-  for (const b of bases) {
-    useStorage().set(_buildCacheKey(key, { group, name }, b), null);
-  }
+  return Promise.all(
+    bases.map((b) => useStorage().set(_buildCacheKey(key, { group, name }, b), null)),
+  );
 }
 
 /** Strips storage-location fields from opts so integrity only reflects the cached computation. */

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -137,9 +137,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
           const evictPromise = _evictFromStorage(key, bases, group, name).catch((error) => {
             _onError("[cache] Cache eviction error.", error);
           });
-          if (event?.req?.waitUntil) {
-            event.req.waitUntil(evictPromise);
-          }
+          event?.req.waitUntil?.(evictPromise);
         }
         // Re-throw error to make sure the caller knows the task failed.
         throw error;
@@ -178,17 +176,13 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
               _onError("[cache] Cache write error.", error);
             }
           })();
-          if (event?.req?.waitUntil) {
-            event.req.waitUntil(promise);
-          }
+          event?.req.waitUntil?.(promise);
         } else {
           // Revalidation produced an invalid result — evict stale entry from storage
           const evictPromise = _evictFromStorage(key, bases, group, name).catch((error) => {
             _onError("[cache] Cache eviction error.", error);
           });
-          if (event?.req?.waitUntil) {
-            event.req.waitUntil(evictPromise);
-          }
+          event?.req.waitUntil?.(evictPromise);
         }
       }
     };
@@ -197,8 +191,8 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
 
     if (entry.value === undefined) {
       await _resolvePromise;
-    } else if (expired && event?.req?.waitUntil) {
-      event.req.waitUntil(_resolvePromise);
+    } else if (expired) {
+      event?.req.waitUntil?.(_resolvePromise);
     }
 
     if (opts.swr && validate(entry) !== false) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -324,8 +324,8 @@ function _normalizeBases(base: CacheOptions["base"]): [string, ...string[]] {
   return [base ?? "/cache"];
 }
 
-function _evictFromStorage(key: string, bases: string[], group: string, name: string) {
-  return Promise.all(
+async function _evictFromStorage(key: string, bases: string[], group: string, name: string) {
+  await Promise.all(
     bases.map((b) => useStorage().set(_buildCacheKey(key, { group, name }, b), null)),
   );
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -222,6 +222,50 @@ describe("cachedFunction", () => {
     errorSpy.mockRestore();
   });
 
+  it("handles cache eviction errors gracefully", async () => {
+    const errors: unknown[] = [];
+    setStorage({
+      get: () => null,
+      set: () => Promise.reject(new Error("evict error")),
+    });
+
+    const fn = defineCachedFunction(
+      async () => {
+        throw new Error("resolver error");
+      },
+      { maxAge: 10, getKey: () => "evict-key", onError: (e) => errors.push(e) },
+    );
+
+    // Original resolver error must propagate, not the eviction error
+    await expect(fn()).rejects.toThrow("resolver error");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe("evict error");
+  });
+
+  it("handles sync cache eviction errors gracefully", async () => {
+    const errors: unknown[] = [];
+    setStorage({
+      get: () => null,
+      set: () => {
+        throw new Error("sync evict error");
+      },
+    });
+
+    const fn = defineCachedFunction(
+      async () => {
+        throw new Error("resolver error");
+      },
+      { maxAge: 10, getKey: () => "evict-key", onError: (e) => errors.push(e) },
+    );
+
+    // A sync throw from storage.set must not mask the original resolver error
+    await expect(fn()).rejects.toThrow("resolver error");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe("sync evict error");
+  });
+
   it("handles malformed cache data", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     setStorage({


### PR DESCRIPTION
Based on the review in https://github.com/unjs/ocache/pull/15#discussion_r3086463678

`_evictFromStorage` was calling `storage.set(..., null)` in a bare `for` loop with no promise handling, leaving rejections from async storage backends unhandled.

- `_evictFromStorage` now returns `Promise.all(...)` instead of fire-and-forgetting in a loop
- Both call sites (resolver rejection + invalid revalidation result) attach a `.catch` that routes errors through the existing `_onError` hook
- When `event.req.waitUntil` is available (srvx / Cloudflare Workers pattern), the eviction promise is registered there so the runtime keeps the request context alive until the eviction completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cache eviction now runs asynchronously, avoids blocking requests, and reports eviction errors to the configured error handler; eviction is scheduled with the request lifecycle when available.
* **Tests**
  * Added tests ensuring eviction/storage failures don't hide original errors and that eviction errors are reported once.
* **Documentation**
  * Updated docs to recommend optional access for request lifecycle scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->