### PR TITLE
feat(cache): add `expireCache` and `.expire()` for SWR-friendly invalidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,10 @@ Never touch contents inside `<!-- automd -->` in README.md. They are auto genera
 
 - `defineCachedFunction(fn, opts)` — wraps any function with caching (SWR, TTL, integrity checks, deduplication of in-flight requests)
 - `cachedFunction(fn, opts)` — alias for `defineCachedFunction`
-- Returned cached function has `.resolveKeys(...args)` and `.invalidate(...args)` methods
+- Returned cached function has `.resolveKeys(...args)`, `.invalidate(...args)`, and `.expire(...args)` methods
 - `resolveCacheKeys({ options, args })` — standalone helper to resolve storage keys
 - `invalidateCache({ options, args })` — standalone helper to remove cached entries across all base prefixes
+- `expireCache({ options, args })` — standalone helper to mark entries stale (`CacheEntry.stale`) without removing them: SWR keeps serving stale within the original `staleMaxAge` window while the next access triggers a background refresh
 - Uses `StorageInterface` via `useStorage()` for persistence
 - Supports `waitUntil` on `event.req` (srvx/Cloudflare ServerRequest pattern) for background cache writes
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ const keys = await getUser.resolveKeys("user-123");
 // ["/cache:functions:getUser:user-123.json"]
 ```
 
+### Cache Expiration (SWR refresh)
+
+While `.invalidate()` removes an entry entirely (the next call must wait for a fresh value), `.expire()` only marks it as stale. With SWR enabled, stale values keep being served — still bounded by the originally configured `staleMaxAge` window — and the next access triggers a background refresh:
+
+```ts
+// Mark the entry stale: next call serves the stale value and refetches in the background
+await getUser.expire("user-123");
+```
+
+The standalone `expireCache()` works like `invalidateCache()` — pass the same `maxAge` / `swr` / `staleMaxAge` options you cache with so the remaining storage TTL is preserved:
+
+```ts
+import { expireCache } from "ocache";
+
+await expireCache({
+  options: { name: "getUser", getKey: (id: string) => id, maxAge: 60, staleMaxAge: 300 },
+  args: ["user-123"],
+});
+```
+
 ### Multi-tier Caching
 
 Use an array of `base` prefixes to enable multi-tier caching. On read, each prefix is tried in order and the first hit is used. On write, the entry is written to all prefixes:
@@ -243,6 +263,41 @@ type EventHandler<E extends HTTPEvent = HTTPEvent> = (
 ```
 
 Handler function that receives an [`HTTPEvent`](#httpevent) and returns a response value.
+
+---
+
+### `expireCache`
+
+```ts
+async function expireCache<ArgsT extends unknown[] = any[]>(
+  input:
+```
+
+Expires cached entries for given arguments and cache options across all base prefixes,
+without removing them.
+
+Unlike [`invalidateCache`](#invalidatecache) (which removes entries entirely), expired entries keep
+serving the stale value with SWR — still bounded by the originally configured
+`staleMaxAge` window — while the next access triggers a background refresh.
+Without SWR, the next call re-resolves before returning.
+
+Uses the same key derivation as `defineCachedFunction` / `resolveCacheKeys`.
+Pass the same `maxAge` / `swr` / `staleMaxAge` options you cache with so the
+remaining storage TTL is preserved.
+
+**Parameters:**
+
+- **`input`** — Object with `options` (cache options) and optional `args` (function arguments).
+
+**Example:**
+
+```ts
+// Mark a cached entry for background refresh on next access
+await expireCache({
+  options: { name: "fetchUser", getKey: (id: string) => id, maxAge: 60, staleMaxAge: 300 },
+  args: ["user-123"],
+});
+```
 
 ---
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -20,6 +20,8 @@ export type CachedFunction<T, ArgsT extends unknown[]> = {
   resolveKeys: (...args: ArgsT) => Promise<string[]>;
   /** Invalidates (removes) cached entries for the given arguments across all base prefixes. */
   invalidate: (...args: ArgsT) => Promise<void>;
+  /** Marks cached entries as stale across all base prefixes. With SWR, stale values are still served (within `staleMaxAge`) while the next access triggers a background refresh. */
+  expire: (...args: ArgsT) => Promise<void>;
 };
 
 /**
@@ -101,6 +103,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
 
     const expired =
       shouldInvalidateCache ||
+      entry.stale === true ||
       entry.integrity !== integrity ||
       opts.maxAge === 0 ||
       (ttl > 0 && Date.now() - (entry.mtime || 0) > ttl) ||
@@ -147,6 +150,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
         // Update mtime, integrity + validate and set the value in cache only the first time the request is made.
         entry.mtime = Date.now();
         entry.integrity = integrity;
+        entry.stale = undefined;
         delete pending[key];
         if (validate(entry) !== false) {
           let setOpts: { ttl?: number } | undefined;
@@ -227,6 +231,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
 
   cachedFn.resolveKeys = (...args: ArgsT) => resolveCacheKeys({ options: opts, args });
   cachedFn.invalidate = (...args: ArgsT) => invalidateCache({ options: opts, args });
+  cachedFn.expire = (...args: ArgsT) => expireCache({ options: opts, args });
 
   return cachedFn;
 }
@@ -299,6 +304,53 @@ export async function invalidateCache<ArgsT extends unknown[] = any[]>(
   await Promise.all(keys.map((key) => storage.set(key, null)));
 }
 
+/**
+ * Expires cached entries for given arguments and cache options across all base prefixes,
+ * without removing them.
+ *
+ * Unlike {@link invalidateCache} (which removes entries entirely), expired entries keep
+ * serving the stale value with SWR — still bounded by the originally configured
+ * `staleMaxAge` window — while the next access triggers a background refresh.
+ * Without SWR, the next call re-resolves before returning.
+ *
+ * Uses the same key derivation as `defineCachedFunction` / `resolveCacheKeys`.
+ * Pass the same `maxAge` / `swr` / `staleMaxAge` options you cache with so the
+ * remaining storage TTL is preserved.
+ *
+ * @param input - Object with `options` (cache options) and optional `args` (function arguments).
+ *
+ * @example
+ * ```ts
+ * // Mark a cached entry for background refresh on next access
+ * await expireCache({
+ *   options: { name: "fetchUser", getKey: (id: string) => id, maxAge: 60, staleMaxAge: 300 },
+ *   args: ["user-123"],
+ * });
+ * ```
+ */
+export async function expireCache<ArgsT extends unknown[] = any[]>(
+  input: {
+    options?: Pick<
+      CacheOptions<any, ArgsT>,
+      "base" | "group" | "name" | "getKey" | "maxAge" | "swr" | "staleMaxAge"
+    >;
+    args?: ArgsT;
+  } = {},
+): Promise<void> {
+  const opts = input.options ?? {};
+  const keys = await resolveCacheKeys(input);
+  const storage = useStorage();
+  await Promise.all(
+    keys.map(async (key) => {
+      const entry = (await storage.get(key)) as CacheEntry | null;
+      if (!entry || typeof entry !== "object" || entry.value === undefined) {
+        return;
+      }
+      await storage.set(key, { ...entry, stale: true }, _remainingTtl(entry, opts));
+    }),
+  );
+}
+
 // --- Internal helpers ---
 
 function isHTTPEvent(input: unknown): input is HTTPEvent {
@@ -328,6 +380,27 @@ async function _evictFromStorage(key: string, bases: string[], group: string, na
   await Promise.all(
     bases.map((b) => useStorage().set(_buildCacheKey(key, { group, name }, b), null)),
   );
+}
+
+/** Computes remaining storage TTL (seconds) so expiring an entry doesn't extend its original lifetime. */
+function _remainingTtl(
+  entry: CacheEntry,
+  opts: Pick<CacheOptions, "maxAge" | "swr" | "staleMaxAge">,
+): { ttl: number } | undefined {
+  if (!entry.mtime || opts.maxAge == null || opts.maxAge <= 0) {
+    return undefined;
+  }
+  // Mirrors the TTL window used on cache writes (see `get` in defineCachedFunction)
+  const ttlWindow =
+    opts.swr === false
+      ? opts.maxAge
+      : opts.staleMaxAge != null && opts.staleMaxAge >= 0
+        ? opts.maxAge + opts.staleMaxAge
+        : undefined;
+  if (ttlWindow === undefined) {
+    return undefined;
+  }
+  return { ttl: Math.max(Math.ceil((entry.mtime + ttlWindow * 1000 - Date.now()) / 1000), 1) };
 }
 
 /** Strips storage-location fields from opts so integrity only reflects the cached computation. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   cachedFunction,
   resolveCacheKeys,
   invalidateCache,
+  expireCache,
   type CachedFunction,
 } from "./cache.ts";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,8 @@ export interface CacheEntry<T = any> {
   mtime?: number;
   /** Hash used to detect when the cached function or options have changed. */
   integrity?: string;
+  /** When `true`, the entry is treated as expired on next access (set by `expireCache`). Cleared after a successful revalidation. */
+  stale?: boolean;
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,6 +5,7 @@ import {
   defineCachedHandler,
   resolveCacheKeys,
   invalidateCache,
+  expireCache,
   createMemoryStorage,
   setStorage,
   useStorage,
@@ -1428,6 +1429,146 @@ describe("invalidateCache", () => {
     await invalidateCache({
       options: { name: "nonexistent", getKey: () => "nope" },
     });
+  });
+});
+
+describe("expireCache", () => {
+  it("SWR serves stale value and refetches in background after expire", async () => {
+    let callCount = 0;
+    const fn = defineCachedFunction(
+      async () => {
+        callCount++;
+        await new Promise((r) => setTimeout(r, 10));
+        return `v${callCount}`;
+      },
+      { maxAge: 60, swr: true, staleMaxAge: 60, name: "myFn", getKey: () => "k" },
+    );
+
+    expect(await fn()).toBe("v1");
+    expect(callCount).toBe(1);
+
+    // Entry is well within maxAge — expire it immediately
+    await fn.expire();
+
+    // Stale value is still served while the refetch runs in the background
+    expect(await fn()).toBe("v1");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(callCount).toBe(2);
+
+    // Background refresh completed — fresh value is now cached
+    expect(await fn()).toBe("v2");
+    expect(callCount).toBe(2);
+  });
+
+  it("clears the stale flag after revalidation", async () => {
+    const fn = defineCachedFunction(() => "value", {
+      maxAge: 60,
+      name: "myFn",
+      getKey: () => "k",
+    });
+
+    await fn();
+    await fn.expire();
+    await fn(); // triggers revalidation (sync resolver updates the entry)
+
+    const keys = await fn.resolveKeys();
+    const entry = (await useStorage().get(keys[0]!)) as any;
+    expect(entry.stale).toBeUndefined();
+  });
+
+  it("swr=false re-resolves before returning after expire", async () => {
+    let callCount = 0;
+    const fn = defineCachedFunction(
+      () => {
+        callCount++;
+        return `v${callCount}`;
+      },
+      { maxAge: 60, swr: false, name: "myFn", getKey: () => "k" },
+    );
+
+    expect(await fn()).toBe("v1");
+    await fn.expire();
+    expect(await fn()).toBe("v2");
+    expect(callCount).toBe(2);
+  });
+
+  it("does not extend the original staleMaxAge window", async () => {
+    let callCount = 0;
+    const fn = defineCachedFunction(
+      async () => {
+        callCount++;
+        await new Promise((r) => setTimeout(r, 5));
+        return `v${callCount}`;
+      },
+      { maxAge: 0.01, swr: true, staleMaxAge: 0.02, name: "myFn", getKey: () => "k" },
+    );
+
+    expect(await fn()).toBe("v1");
+    await fn.expire();
+
+    // Wait beyond maxAge + staleMaxAge — entry is fully expired, stale must NOT be served
+    await new Promise((r) => setTimeout(r, 50));
+    expect(await fn()).toBe("v2");
+    expect(callCount).toBe(2);
+  });
+
+  it("preserves remaining storage TTL when expiring", async () => {
+    const opts = { maxAge: 60, swr: true, staleMaxAge: 120, name: "myFn", getKey: () => "k" };
+    const fn = defineCachedFunction(() => "value", opts);
+    await fn();
+
+    const storage = useStorage();
+    const setSpy = vi.spyOn(storage, "set");
+
+    await fn.expire();
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ stale: true, value: "value" }),
+      { ttl: 180 },
+    );
+  });
+
+  it("expires across all base prefixes (multi-tier)", async () => {
+    const fn = defineCachedFunction(() => "value", {
+      maxAge: 60,
+      base: ["/tier1", "/tier2"],
+      name: "myFn",
+      getKey: () => "k",
+    });
+
+    await fn();
+    await fn.expire();
+
+    const storage = useStorage();
+    const tier1 = (await storage.get("/tier1:functions:myFn:k.json")) as any;
+    const tier2 = (await storage.get("/tier2:functions:myFn:k.json")) as any;
+    expect(tier1.stale).toBe(true);
+    expect(tier1.value).toBe("value");
+    expect(tier2.stale).toBe(true);
+  });
+
+  it("standalone expireCache works with same options", async () => {
+    let callCount = 0;
+    const opts = { maxAge: 60, name: "myFn", getKey: () => "k", swr: false } as const;
+    const fn = defineCachedFunction(() => {
+      callCount++;
+      return `v${callCount}`;
+    }, opts);
+
+    expect(await fn()).toBe("v1");
+
+    await expireCache({ options: opts });
+
+    expect(await fn()).toBe("v2");
+    expect(callCount).toBe(2);
+  });
+
+  it("expiring non-existent key is a no-op", async () => {
+    // Should not throw and should not create an entry
+    await expireCache({
+      options: { name: "nonexistent", getKey: () => "nope" },
+    });
+    expect(await useStorage().get("/cache:functions:nonexistent:nope.json")).toBeNull();
   });
 });
 


### PR DESCRIPTION
Adds a soft invalidation API: unlike `.invalidate()` (which removes the entry), `.expire()` marks it stale — with SWR the stale value keeps being served (still bounded by the original `staleMaxAge` window) while the next access triggers a background refresh.

```ts
const getUser = defineCachedFunction(async (id: string) => db.users.find(id), {
  name: "getUser",
  maxAge: 60,
  staleMaxAge: 300,
  getKey: (id: string) => id,
});

// Mark the entry stale: next call serves the stale value and refetches in the background
await getUser.expire("user-123");
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) (thanks @atinux for idea!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `.expire()` method to cached functions for marking entries as stale
  * Added `expireCache()` helper function to externally expire cache entries
  * Enabled Stale-While-Revalidate (SWR) behavior: stale values are served while background refresh occurs

* **Documentation**
  * Expanded API reference with cache expiration usage and examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->