### PR TITLE
feat: warn when recompute is cheaper than cache retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ const cached = defineCachedFunction(fn, {
   validate: (entry) => entry.value !== undefined, // Custom validation
   transform: (entry) => entry.value, // Transform before returning
   onError: (error) => console.error(error), // Error handler
+  warnWhenSlower: false, // Warn once when recompute is meaningfully cheaper than retrieval (default: false)
 });
 ```
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -44,6 +44,9 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
   const name = opts.name || fn.name || "_";
   const integrity = opts.integrity || hash([fn, _integrityOpts(opts)]);
   const validate = opts.validate || ((entry) => entry.value !== undefined);
+  const _perf: PerfState | undefined = opts.warnWhenSlower
+    ? { hits: [], computes: [], warned: false }
+    : undefined;
   const _onError = (context: string, error: unknown) => {
     if (opts.onError) {
       opts.onError(error);
@@ -67,10 +70,12 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
     try {
       // Multi-tier read: try each base prefix in order, use first hit
       for (let i = 0; i < bases.length; i++) {
+        const _start = _perf ? performance.now() : 0;
         const result = (await useStorage().get(
           _buildCacheKey(key, { group, name }, bases[i]!),
         )) as CacheEntry<T> | null;
         if (result) {
+          if (_perf) _trackEfficiency(_perf, "hits", performance.now() - _start, group, name);
           entry = result;
           hitIndex = i;
           break;
@@ -119,6 +124,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
 
     const _resolve = async () => {
       const isPending = pending[key];
+      let _computeStart = 0;
       if (!isPending) {
         if (entry.value !== undefined && (opts.staleMaxAge || 0) >= 0 && opts.swr === false) {
           // Remove cached entry to prevent using expired cache on concurrent requests
@@ -127,6 +133,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
           entry.mtime = undefined;
           entry.expires = undefined;
         }
+        if (_perf) _computeStart = performance.now();
         pending[key] = Promise.resolve(resolver());
       }
 
@@ -147,6 +154,9 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       }
 
       if (!isPending) {
+        if (_perf) {
+          _trackEfficiency(_perf, "computes", performance.now() - _computeStart, group, name);
+        }
         // Update mtime, integrity + validate and set the value in cache only the first time the request is made.
         entry.mtime = Date.now();
         entry.integrity = integrity;
@@ -407,4 +417,56 @@ function _remainingTtl(
 function _integrityOpts(opts: CacheOptions): Omit<CacheOptions, "base" | "group" | "name"> {
   const { base: _, group: _g, name: _n, ...rest } = opts;
   return rest;
+}
+
+// --- Cache efficiency warning (opt-in via `warnWhenSlower`) ---
+
+const MIN_HITS = 5;
+const SAMPLE_SIZE = 20;
+// Only flag when retrieval is genuinely non-trivial (fast/local storage overhead is negligible and
+// sub-millisecond timings are mostly noise) and clearly dominates recompute.
+const MIN_RETRIEVAL_MS = 1;
+const SLOWER_MARGIN = 2;
+
+interface PerfState {
+  hits: number[];
+  computes: number[];
+  warned: boolean;
+}
+
+/** Records a retrieval/recompute sample and warns once when recompute is the cheaper of the two. */
+function _trackEfficiency(
+  perf: PerfState,
+  kind: "hits" | "computes",
+  ms: number,
+  group: string,
+  name: string,
+): void {
+  if (perf.warned) {
+    return;
+  }
+  const samples = perf[kind];
+  samples.push(ms);
+  if (samples.length > SAMPLE_SIZE) {
+    samples.shift();
+  }
+  if (perf.computes.length === 0 || perf.hits.length < MIN_HITS) {
+    return;
+  }
+  const computeMs = _median(perf.computes);
+  const retrievalMs = _median(perf.hits);
+  if (retrievalMs >= MIN_RETRIEVAL_MS && computeMs * SLOWER_MARGIN <= retrievalMs) {
+    perf.warned = true;
+    console.warn(
+      `[cache] Recomputing "${group}:${name}" (~${computeMs.toFixed(3)}ms) is cheaper than ` +
+        `retrieving it from the cache (~${retrievalMs.toFixed(3)}ms). Caching may be adding ` +
+        `overhead here — consider removing it. (heuristic; production cost may differ)`,
+    );
+  }
+}
+
+function _median(samples: number[]): number {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,14 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
   base?: string | string[];
   /** Optional error handler called for all cache-related errors (read, write, SWR, malformed data). */
   onError?: (error: unknown) => void;
+  /**
+   * When `true`, measure retrieval vs. recompute time and emit a one-time `console.warn`
+   * when retrieval is non-trivial and recomputing the value is meaningfully cheaper than
+   * reading it back from the cache (i.e. caching adds net overhead here). Fast/local storage
+   * never triggers it. Adds negligible cost when disabled. Intended for development.
+   * Defaults to `false`.
+   */
+  warnWhenSlower?: boolean;
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
   cachedFunction,
   defineCachedFunction,
@@ -10,6 +10,7 @@ import {
   setStorage,
   useStorage,
   type HTTPEvent,
+  type StorageInterface,
 } from "../src/index.ts";
 beforeEach(() => {
   setStorage(createMemoryStorage());
@@ -1725,5 +1726,121 @@ describe("multi-tier base", () => {
     const result = await fn2();
     expect(result).toBe("from-tier1");
     expect(callCount).toBe(0);
+  });
+});
+
+describe("warnWhenSlower", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function slowReadStorage(delayMs = 15): StorageInterface {
+    const base = createMemoryStorage();
+    return {
+      get: async (key: string) => {
+        await new Promise((r) => setTimeout(r, delayMs));
+        return base.get(key);
+      },
+      set: (key: string, value: unknown, opts?: { ttl?: number }) => base.set(key, value, opts),
+    } as StorageInterface;
+  }
+
+  it("warns once when recompute is cheaper than retrieval", async () => {
+    setStorage(slowReadStorage());
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fn = defineCachedFunction(() => "fast", {
+      maxAge: 1000,
+      name: "slow-cache",
+      warnWhenSlower: true,
+    });
+
+    for (let i = 0; i < 10; i++) {
+      await fn();
+    }
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]![0]).toContain('Recomputing "functions:slow-cache"');
+    expect(warnSpy.mock.calls[0]![0]).toContain("cheaper than");
+  });
+
+  it("does not warn when disabled (default)", async () => {
+    setStorage(slowReadStorage());
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fn = defineCachedFunction(() => "fast", { maxAge: 1000, name: "no-warn" });
+
+    for (let i = 0; i < 10; i++) {
+      await fn();
+    }
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when recompute is more expensive than retrieval", async () => {
+    setStorage(createMemoryStorage());
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fn = defineCachedFunction(
+      async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return "slow";
+      },
+      { maxAge: 1000, name: "expensive", warnWhenSlower: true },
+    );
+
+    for (let i = 0; i < 10; i++) {
+      await fn();
+    }
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not warn for a cheap function on fast in-memory storage", async () => {
+    setStorage(createMemoryStorage());
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fn = defineCachedFunction(() => 42, {
+      maxAge: 1000,
+      name: "cheap",
+      warnWhenSlower: true,
+    });
+
+    for (let i = 0; i < 20; i++) {
+      await fn();
+    }
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not warn before enough retrieval samples are collected", async () => {
+    setStorage(slowReadStorage());
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fn = defineCachedFunction(() => "fast", {
+      maxAge: 1000,
+      name: "few-hits",
+      warnWhenSlower: true,
+    });
+
+    // 1 miss (compute) + 4 hits: below the 5-hit minimum.
+    for (let i = 0; i < 5; i++) {
+      await fn();
+    }
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns for cached handlers (http path)", async () => {
+    setStorage(slowReadStorage());
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = defineCachedHandler(() => new Response("hello"), {
+      maxAge: 1000,
+      name: "slow-handler",
+      warnWhenSlower: true,
+    });
+    const event = { req: new Request("http://localhost/slow-handler") };
+
+    for (let i = 0; i < 10; i++) {
+      await handler(event);
+    }
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]![0]).toContain('Recomputing "handlers:slow-handler"');
   });
 });


### PR DESCRIPTION
Adds an opt-in `warnWhenSlower` option to `CacheOptions`. When enabled, ocache
times cache retrieval (a hit `get`) against recompute (the resolver on a miss/
refresh) and emits a one-time `console.warn` when recomputing the value is
cheaper than reading it back from the cache — i.e. caching is adding net
overhead for that cache.

- Off by default; only tracks when the option is set, so no cost for existing users.
- Measured directly around the resolver and storage read (no function wrapping),
  so integrity hashing is unaffected. Handles request dedup and SWR refreshes.
- Works for both `defineCachedFunction` and `defineCachedHandler`.

Addresses nitrojs/nitro#2559/nitrojs/nitro#4401 (Nitro enables it in dev via `import.meta.dev`).

Usage:

    const getUser = defineCachedFunction(fetchUser, { warnWhenSlower: true })
