### PR TITLE
feat(cache): add onCacheEvent lifecycle hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ const cached = defineCachedFunction(fn, {
   validate: (entry) => entry.value !== undefined, // Custom validation
   transform: (entry) => entry.value, // Transform before returning
   onError: (error) => console.error(error), // Error handler
+  onCacheEvent: (event) => {}, // Lifecycle hook: hit/miss/stale/set/evict
 });
 ```
 
@@ -146,6 +147,63 @@ await expireCache({
 });
 ```
 
+### Cache Events
+
+Pass an `onCacheEvent` hook to observe the cache lifecycle — hits, misses, stale serves, writes, and evictions. Use it for metrics, audit logging, cascading invalidations, or debugging. The hook is a superset of an "update/eviction" callback: filter for `set`/`evict` to react to changes, and read `oldValue`/`newValue`/`reason` to compare before/after.
+
+```ts
+const getUser = defineCachedFunction(fetchUser, {
+  maxAge: 60,
+  staleMaxAge: 300,
+  onCacheEvent(event) {
+    switch (event.type) {
+      case "hit": // fresh value served
+      case "miss": // nothing cached, resolver ran
+      case "stale": // stale value served, refreshing in background
+        break;
+      case "set": // written to storage
+        // event.oldValue, event.newValue
+        // event.reason: "initial" | "maxAge" | "stale" | "invalid" | "manual"
+        break;
+      case "evict": // removed from storage
+        // event.oldValue
+        // event.reason: "error" | "invalid" | "manual"
+        break;
+    }
+  },
+});
+```
+
+Every event carries a `key` (the resolved cache key) and a `name` — the cached function's `name`, or the request route for HTTP handlers. The hook fires synchronously for the served value and again from background SWR refreshes. Errors thrown inside it are routed to `onError` and never affect caching; it also has no effect on integrity, so adding or removing it never invalidates existing entries.
+
+Event types are also exported as `CacheEventType` constants, so you can avoid string literals — `event.type === CacheEventType.Hit` (values are plain strings, so `=== "hit"` still works):
+
+```ts
+import { CacheEventType } from "ocache";
+
+onCacheEvent(event) {
+  if (event.type === CacheEventType.Evict) {
+    /* ... */
+  }
+}
+```
+
+`onCacheEvent` works the same on `defineCachedHandler`, where `name` is the request route. A minimal dev logger:
+
+```ts
+const handler = defineCachedHandler(render, {
+  maxAge: 2,
+  swr: true,
+  onCacheEvent(event) {
+    if (event.type === "set" && event.reason === "initial") {
+      console.log(`Added cache entry for '${event.name}', swr enabled`);
+    } else {
+      console.log(`Cache ${event.type} for '${event.name}'`);
+    }
+  },
+});
+```
+
 ### Multi-tier Caching
 
 Use an array of `base` prefixes to enable multi-tier caching. On read, each prefix is tried in order and the first hit is used. On write, the entry is written to all prefixes:
@@ -194,6 +252,18 @@ setStorage(redisStorage);
 
 <!-- automd:docs4ts -->
 
+### `_integrityOpts`
+
+```ts
+function _integrityOpts<O extends CacheOptions>(
+  opts: O,
+): Omit<O, "base" | "group" | "name" | "onCacheEvent">;
+```
+
+Strips storage-location and observability fields from opts so integrity only reflects the cached computation.
+
+---
+
 ### `cachedFunction`
 
 ```ts
@@ -201,6 +271,84 @@ const cachedFunction = defineCachedFunction;
 ```
 
 Alias for [`defineCachedFunction`](#definecachedfunction).
+
+---
+
+### `CacheEvent`
+
+```ts
+type CacheEvent<T = any> =
+  |
+```
+
+A cache lifecycle event passed to the {@link CacheOptions.onCacheEvent} hook.
+
+A discriminated union on `type` ([`CacheEventType`](#cacheeventtype)):
+
+- `hit` — a fresh cached value was served.
+- `miss` — nothing servable was cached; the resolver ran to populate it.
+- `stale` — a stale value was served while a background refresh runs (SWR).
+- `set` — a value was (re)written to storage (carries `oldValue`/`newValue`/`reason`).
+- `evict` — an entry was removed from storage (carries `oldValue`/`reason`).
+
+`key` is the resolved logical cache key; `name` is a human-readable label
+(the cached function's `name`, or the request route for HTTP handlers). For HTTP
+handlers `name` is the raw route including the query string, so sanitize it before
+logging if URLs may carry secrets.
+
+---
+
+### `CacheEventType`
+
+```ts
+const CacheEventType =
+```
+
+Cache lifecycle event types (the `type` discriminant of [`CacheEvent`](#cacheevent)).
+
+Importable named constants so consumers can avoid string literals:
+`if (event.type === CacheEventType.Hit)`. The values are plain strings, so
+`event.type === "hit"` keeps working too.
+
+---
+
+### `CacheEventType`
+
+```ts
+type CacheEventType = (typeof CacheEventType)[keyof typeof CacheEventType];
+```
+
+Union of [`CacheEventType`](#cacheeventtype) values (`"hit" | "miss" | "stale" | "set" | "evict"`).
+
+---
+
+### `CacheEvictReason`
+
+```ts
+type CacheEvictReason = "error" | "invalid" | "manual";
+```
+
+Reason a cache entry was removed, passed on `evict` [`CacheEvent`](#cacheevent)s.
+
+- `error` — the resolver threw, so the stale entry was dropped.
+- `invalid` — revalidation produced a value that failed `validate()`.
+- `manual` — removed via `invalidateCache` / `.invalidate()`.
+
+---
+
+### `CacheSetReason`
+
+```ts
+type CacheSetReason = "initial" | "maxAge" | "stale" | "invalid" | "manual";
+```
+
+Reason a cache entry was (re)written, passed on `set` [`CacheEvent`](#cacheevent)s.
+
+- `initial` — first population (no previous value).
+- `maxAge` — the previous value's TTL (`maxAge`) had elapsed.
+- `stale` — the entry had been marked stale (e.g. by `expireCache`).
+- `invalid` — integrity changed or `validate()` rejected the previous value.
+- `manual` — re-resolved because `shouldInvalidateCache` returned `true`.
 
 ---
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,7 +1,7 @@
 import { hash } from "ohash";
 import { useStorage } from "./storage.ts";
 
-import type { HTTPEvent, CacheEntry, CacheOptions } from "./types.ts";
+import type { HTTPEvent, CacheEntry, CacheEvent, CacheSetReason, CacheOptions } from "./types.ts";
 
 function defaultCacheOptions() {
   return {
@@ -51,6 +51,13 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       console.error(context, error);
     }
   };
+  const _emit = (event: CacheEvent<T>) => {
+    try {
+      opts.onCacheEvent!(event);
+    } catch (error) {
+      _onError("[cache] onCacheEvent handler error.", error);
+    }
+  };
 
   async function get(
     key: string,
@@ -60,6 +67,9 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
   ): Promise<ResolvedCacheEntry<T>> {
     // Use extension for key to avoid conflicting with parent namespace (foo/bar and foo/bar/baz)
     const bases = _normalizeBases(opts.base);
+
+    const _hasHook = !!opts.onCacheEvent;
+    const displayName = _hasHook ? _eventName(event, name) : "";
 
     let entry: CacheEntry<T> = {} as CacheEntry<T>;
     // Index of the base that had a cache hit (-1 = miss on all tiers)
@@ -101,13 +111,20 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
     const isFullyExpired =
       staleTtl !== undefined && ttl > 0 && Date.now() - (entry.mtime || 0) > ttl + staleTtl;
 
+    const _stale = entry.stale === true;
+    const _integrityMismatch = entry.integrity !== integrity;
+    const _ttlExpired = ttl > 0 && Date.now() - (entry.mtime || 0) > ttl;
+    // Evaluate validate eagerly only for the hook's reason; without a hook it stays the
+    // short-circuiting final operand of `expired`, keeping the original call pattern intact.
+    const _validateFailed = _hasHook ? validate(entry) === false : false;
+
     const expired =
       shouldInvalidateCache ||
-      entry.stale === true ||
-      entry.integrity !== integrity ||
+      _stale ||
+      _integrityMismatch ||
       opts.maxAge === 0 ||
-      (ttl > 0 && Date.now() - (entry.mtime || 0) > ttl) ||
-      validate(entry) === false;
+      _ttlExpired ||
+      (_hasHook ? _validateFailed : validate(entry) === false);
 
     // If fully expired beyond staleMaxAge, clear the stale value so SWR won't serve it
     if (isFullyExpired) {
@@ -115,6 +132,29 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       entry.integrity = undefined;
       entry.mtime = undefined;
       entry.expires = undefined;
+    }
+
+    // Captured after the fully-expired clear so a dead entry reads as a fresh (re)population.
+    const oldValue = entry.value;
+
+    const _setReason = _hasHook
+      ? (): CacheSetReason => {
+          if (oldValue === undefined) return "initial";
+          if (shouldInvalidateCache) return "manual";
+          if (_stale) return "stale";
+          if (_integrityMismatch || _validateFailed) return "invalid";
+          return "maxAge";
+        }
+      : undefined;
+
+    if (_hasHook) {
+      if (entry.value !== undefined && !expired) {
+        _emit({ type: "hit", key, name: displayName, value: entry.value });
+      } else if (entry.value !== undefined && opts.swr && !_validateFailed) {
+        _emit({ type: "stale", key, name: displayName, value: entry.value });
+      } else {
+        _emit({ type: "miss", key, name: displayName });
+      }
     }
 
     const _resolve = async () => {
@@ -141,6 +181,9 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
             _onError("[cache] Cache eviction error.", error);
           });
           event?.req.waitUntil?.(evictPromise);
+          if (_hasHook && oldValue !== undefined) {
+            _emit({ type: "evict", key, name: displayName, oldValue, reason: "error" });
+          }
         }
         // Re-throw error to make sure the caller knows the task failed.
         throw error;
@@ -176,6 +219,16 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
                   useStorage().set(_buildCacheKey(key, { group, name }, b), entry, setOpts),
                 ),
               );
+              if (_hasHook) {
+                _emit({
+                  type: "set",
+                  key,
+                  name: displayName,
+                  oldValue,
+                  newValue: entry.value as T,
+                  reason: _setReason!(),
+                });
+              }
             } catch (error) {
               _onError("[cache] Cache write error.", error);
             }
@@ -187,6 +240,9 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
             _onError("[cache] Cache eviction error.", error);
           });
           event?.req.waitUntil?.(evictPromise);
+          if (_hasHook && oldValue !== undefined) {
+            _emit({ type: "evict", key, name: displayName, oldValue, reason: "invalid" });
+          }
         }
       }
     };
@@ -295,13 +351,49 @@ export async function resolveCacheKeys<ArgsT extends unknown[] = any[]>(
  */
 export async function invalidateCache<ArgsT extends unknown[] = any[]>(
   input: {
-    options?: Pick<CacheOptions<any, ArgsT>, "base" | "group" | "name" | "getKey">;
+    options?: Pick<
+      CacheOptions<any, ArgsT>,
+      "base" | "group" | "name" | "getKey" | "onCacheEvent" | "onError"
+    >;
     args?: ArgsT;
   } = {},
 ): Promise<void> {
-  const keys = await resolveCacheKeys(input);
+  const opts = input.options ?? {};
+  const args = input.args ?? ([] as unknown as ArgsT);
+  const key = await (opts.getKey || getKey)(...args);
+  const keys = _normalizeBases(opts.base).map((base) => _buildCacheKey(key, opts, base));
   const storage = useStorage();
-  await Promise.all(keys.map((key) => storage.set(key, null)));
+
+  // Read the current value only when a hook needs it (first tier that has one wins).
+  // A failed read must never block the removal below, so errors are swallowed to onError.
+  let oldValue: unknown;
+  if (opts.onCacheEvent) {
+    try {
+      const entries = (await Promise.all(keys.map((k) => storage.get(k)))) as (CacheEntry | null)[];
+      oldValue = entries.find((e) => e && typeof e === "object" && e.value !== undefined)?.value;
+    } catch (error) {
+      if (opts.onError) {
+        opts.onError(error);
+      } else {
+        console.error("[cache] Cache read error.", error);
+      }
+    }
+  }
+
+  await Promise.all(keys.map((k) => storage.set(k, null)));
+
+  // Only emit when an entry was actually removed.
+  if (opts.onCacheEvent && oldValue !== undefined) {
+    try {
+      opts.onCacheEvent({ type: "evict", key, name: opts.name || "_", oldValue, reason: "manual" });
+    } catch (error) {
+      if (opts.onError) {
+        opts.onError(error);
+      } else {
+        console.error("[cache] onCacheEvent handler error.", error);
+      }
+    }
+  }
 }
 
 /**
@@ -361,6 +453,19 @@ function getKey(...args: unknown[]) {
   return args.length > 0 ? hash(args) : "";
 }
 
+/** Readable label for a lifecycle event: the request route for HTTP events, else the given name. */
+function _eventName(event: HTTPEvent | undefined, name: string): string {
+  if (event) {
+    try {
+      const url = event.url ?? new URL(event.req.url);
+      return url.pathname + url.search;
+    } catch {
+      // fall through to name
+    }
+  }
+  return name;
+}
+
 function _buildCacheKey(
   key: string,
   opts: Pick<CacheOptions, "group" | "name">,
@@ -403,8 +508,10 @@ function _remainingTtl(
   return { ttl: Math.max(Math.ceil((entry.mtime + ttlWindow * 1000 - Date.now()) / 1000), 1) };
 }
 
-/** Strips storage-location fields from opts so integrity only reflects the cached computation. */
-function _integrityOpts(opts: CacheOptions): Omit<CacheOptions, "base" | "group" | "name"> {
-  const { base: _, group: _g, name: _n, ...rest } = opts;
+/** Strips storage-location and observability fields from opts so integrity only reflects the cached computation. */
+export function _integrityOpts<O extends CacheOptions>(
+  opts: O,
+): Omit<O, "base" | "group" | "name" | "onCacheEvent"> {
+  const { base: _, group: _g, name: _n, onCacheEvent: _e, ...rest } = opts;
   return rest;
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,5 +1,5 @@
 import { hash } from "ohash";
-import { cachedFunction } from "./cache.ts";
+import { cachedFunction, _integrityOpts } from "./cache.ts";
 
 import type {
   HTTPEvent,
@@ -200,14 +200,6 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
 
 function escapeKey(key: string | string[]) {
   return String(key).replace(/\W/g, "");
-}
-
-/** Strips storage-location fields from opts so integrity only reflects the cached computation. */
-function _integrityOpts<E extends HTTPEvent>(
-  opts: CachedEventHandlerOptions<E>,
-): Omit<CachedEventHandlerOptions<E>, "base" | "group" | "name"> {
-  const { base: _, group: _g, name: _n, ...rest } = opts;
-  return rest;
 }
 
 function _defaultHandleCacheHeaders(event: HTTPEvent, conditions: CacheConditions): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,16 @@ export { defineCachedHandler } from "./http.ts";
 
 export { type StorageInterface, createMemoryStorage, useStorage, setStorage } from "./storage.ts";
 
+export { CacheEventType } from "./types.ts";
+
 export type {
   HTTPEvent,
   ServerRequest,
   EventHandler,
   CacheEntry,
+  CacheEvent,
+  CacheSetReason,
+  CacheEvictReason,
   CacheOptions,
   CachedEventHandlerOptions,
   CacheConditions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,79 @@ export interface CacheEntry<T = any> {
 }
 
 /**
+ * Reason a cache entry was (re)written, passed on `set` {@link CacheEvent}s.
+ *
+ * - `initial` — first population (no previous value).
+ * - `maxAge` — the previous value's TTL (`maxAge`) had elapsed.
+ * - `stale` — the entry had been marked stale (e.g. by `expireCache`).
+ * - `invalid` — integrity changed or `validate()` rejected the previous value.
+ * - `manual` — re-resolved because `shouldInvalidateCache` returned `true`.
+ */
+export type CacheSetReason = "initial" | "maxAge" | "stale" | "invalid" | "manual";
+
+/**
+ * Reason a cache entry was removed, passed on `evict` {@link CacheEvent}s.
+ *
+ * - `error` — the resolver threw, so the stale entry was dropped.
+ * - `invalid` — revalidation produced a value that failed `validate()`.
+ * - `manual` — removed via `invalidateCache` / `.invalidate()`.
+ */
+export type CacheEvictReason = "error" | "invalid" | "manual";
+
+/**
+ * Cache lifecycle event types (the `type` discriminant of {@link CacheEvent}).
+ *
+ * Importable named constants so consumers can avoid string literals:
+ * `if (event.type === CacheEventType.Hit)`. The values are plain strings, so
+ * `event.type === "hit"` keeps working too.
+ */
+export const CacheEventType = {
+  Hit: "hit",
+  Miss: "miss",
+  Stale: "stale",
+  Set: "set",
+  Evict: "evict",
+} as const;
+
+/** Union of {@link CacheEventType} values (`"hit" | "miss" | "stale" | "set" | "evict"`). */
+export type CacheEventType = (typeof CacheEventType)[keyof typeof CacheEventType];
+
+/**
+ * A cache lifecycle event passed to the {@link CacheOptions.onCacheEvent} hook.
+ *
+ * A discriminated union on `type` ({@link CacheEventType}):
+ * - `hit` — a fresh cached value was served.
+ * - `miss` — nothing servable was cached; the resolver ran to populate it.
+ * - `stale` — a stale value was served while a background refresh runs (SWR).
+ * - `set` — a value was (re)written to storage (carries `oldValue`/`newValue`/`reason`).
+ * - `evict` — an entry was removed from storage (carries `oldValue`/`reason`).
+ *
+ * `key` is the resolved logical cache key; `name` is a human-readable label
+ * (the cached function's `name`, or the request route for HTTP handlers). For HTTP
+ * handlers `name` is the raw route including the query string, so sanitize it before
+ * logging if URLs may carry secrets.
+ */
+export type CacheEvent<T = any> =
+  | { type: typeof CacheEventType.Hit; key: string; name: string; value: T }
+  | { type: typeof CacheEventType.Miss; key: string; name: string }
+  | { type: typeof CacheEventType.Stale; key: string; name: string; value: T }
+  | {
+      type: typeof CacheEventType.Set;
+      key: string;
+      name: string;
+      oldValue?: T;
+      newValue: T;
+      reason: CacheSetReason;
+    }
+  | {
+      type: typeof CacheEventType.Evict;
+      key: string;
+      name: string;
+      oldValue: T;
+      reason: CacheEvictReason;
+    };
+
+/**
  * Options for configuring cached functions created by `defineCachedFunction`.
  */
 export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
@@ -70,6 +143,15 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
   base?: string | string[];
   /** Optional error handler called for all cache-related errors (read, write, SWR, malformed data). */
   onError?: (error: unknown) => void;
+  /**
+   * Observability hook called on cache lifecycle events (`hit`, `miss`, `stale`, `set`, `evict`).
+   *
+   * Fires synchronously for the served value and (for background SWR refreshes) when the
+   * refresh writes or evicts. Errors thrown here are caught and routed to `onError` — they
+   * never affect caching. Does not influence integrity, so adding/removing it never
+   * invalidates existing entries.
+   */
+  onCacheEvent?: (event: CacheEvent<T>) => void;
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,7 +9,9 @@ import {
   createMemoryStorage,
   setStorage,
   useStorage,
+  CacheEventType,
   type HTTPEvent,
+  type CacheEvent,
 } from "../src/index.ts";
 beforeEach(() => {
   setStorage(createMemoryStorage());
@@ -1725,5 +1727,378 @@ describe("multi-tier base", () => {
     const result = await fn2();
     expect(result).toBe("from-tier1");
     expect(callCount).toBe(0);
+  });
+});
+
+describe("onCacheEvent", () => {
+  it("emits miss then set(initial) on first population and hit afterwards", async () => {
+    const events: CacheEvent[] = [];
+    const fn = defineCachedFunction(() => "v1", {
+      maxAge: 60,
+      getKey: () => "k",
+      onCacheEvent: (e) => events.push(e),
+    });
+
+    await fn();
+    await fn();
+
+    expect(events.map((e) => e.type)).toEqual(["miss", "set", "hit"]);
+    const set = events[1] as Extract<CacheEvent, { type: "set" }>;
+    expect(set).toMatchObject({ key: "k", oldValue: undefined, newValue: "v1", reason: "initial" });
+    expect(events[2]).toMatchObject({ type: "hit", value: "v1" });
+  });
+
+  it("emits stale while serving then set(maxAge) from the background refresh (SWR)", async () => {
+    const events: CacheEvent[] = [];
+    let n = 0;
+    const fn = defineCachedFunction(
+      async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return `v${++n}`;
+      },
+      {
+        maxAge: 0.02,
+        swr: true,
+        staleMaxAge: 10,
+        getKey: () => "k",
+        onCacheEvent: (e) => events.push(e),
+      },
+    );
+
+    await fn();
+    await new Promise((r) => setTimeout(r, 40));
+    const served = await fn();
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(served).toBe("v1");
+    expect(events.some((e) => e.type === "stale")).toBe(true);
+    const set = events.filter((e) => e.type === "set").at(-1) as Extract<
+      CacheEvent,
+      { type: "set" }
+    >;
+    expect(set).toMatchObject({ oldValue: "v1", newValue: "v2", reason: "maxAge" });
+  });
+
+  it("emits set(stale) after expireCache marks the entry stale", async () => {
+    const events: CacheEvent[] = [];
+    let n = 0;
+    const options = {
+      maxAge: 60,
+      swr: false,
+      getKey: () => "k",
+      onCacheEvent: (e: CacheEvent) => events.push(e),
+    };
+    const fn = defineCachedFunction(() => `v${++n}`, options);
+
+    await fn();
+    await expireCache({ options });
+    await fn();
+
+    const set = events.filter((e) => e.type === "set").at(-1) as Extract<
+      CacheEvent,
+      { type: "set" }
+    >;
+    expect(set).toMatchObject({ oldValue: "v1", newValue: "v2", reason: "stale" });
+  });
+
+  it("emits set(invalid) when the previous value's integrity no longer matches", async () => {
+    const events: CacheEvent[] = [];
+    const fn = defineCachedFunction(() => "fresh", {
+      maxAge: 60,
+      swr: false,
+      getKey: () => "k",
+      onCacheEvent: (e) => events.push(e),
+    });
+
+    const [storageKey] = await fn.resolveKeys();
+    await useStorage().set(storageKey!, {
+      value: "stale",
+      integrity: "outdated",
+      mtime: Date.now(),
+    });
+
+    await fn();
+
+    const set = events.filter((e) => e.type === "set").at(-1) as Extract<
+      CacheEvent,
+      { type: "set" }
+    >;
+    expect(set).toMatchObject({ oldValue: "stale", newValue: "fresh", reason: "invalid" });
+  });
+
+  it("emits evict(error) when a background refresh rejects", async () => {
+    const events: CacheEvent[] = [];
+    let n = 0;
+    const fn = defineCachedFunction(
+      async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        if (++n > 1) throw new Error("boom");
+        return "v1";
+      },
+      {
+        maxAge: 0.02,
+        swr: true,
+        staleMaxAge: 10,
+        getKey: () => "k",
+        onCacheEvent: (e) => events.push(e),
+        onError: () => {},
+      },
+    );
+
+    await fn();
+    await new Promise((r) => setTimeout(r, 40));
+    const served = await fn();
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(served).toBe("v1");
+    const evict = events.filter((e) => e.type === "evict").at(-1) as Extract<
+      CacheEvent,
+      { type: "evict" }
+    >;
+    expect(evict).toMatchObject({ oldValue: "v1", reason: "error" });
+  });
+
+  it("emits evict(invalid) when a background refresh produces an invalid value", async () => {
+    const events: CacheEvent[] = [];
+    let n = 0;
+    const fn = defineCachedFunction(
+      async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return n++ === 0 ? "v1" : "v2";
+      },
+      {
+        maxAge: 0.02,
+        swr: true,
+        staleMaxAge: 10,
+        getKey: () => "k",
+        validate: (entry) => entry.value !== "v2",
+        onCacheEvent: (e) => events.push(e),
+      },
+    );
+
+    await fn();
+    await new Promise((r) => setTimeout(r, 40));
+    await fn();
+    await new Promise((r) => setTimeout(r, 40));
+
+    const evict = events.filter((e) => e.type === "evict").at(-1) as Extract<
+      CacheEvent,
+      { type: "evict" }
+    >;
+    expect(evict).toMatchObject({ oldValue: "v1", reason: "invalid" });
+  });
+
+  it("emits evict(manual) with the old value on invalidate", async () => {
+    const events: CacheEvent[] = [];
+    const fn = defineCachedFunction(() => "v1", {
+      maxAge: 60,
+      name: "myFn",
+      getKey: () => "k",
+      onCacheEvent: (e) => events.push(e),
+    });
+
+    await fn();
+    await fn.invalidate();
+
+    const evict = events.filter((e) => e.type === "evict").at(-1) as Extract<
+      CacheEvent,
+      { type: "evict" }
+    >;
+    expect(evict).toMatchObject({ key: "k", name: "myFn", oldValue: "v1", reason: "manual" });
+  });
+
+  it("uses the request route as the event name for HTTP handlers", async () => {
+    const events: CacheEvent[] = [];
+    const handler = defineCachedHandler(() => new Response("ok"), {
+      maxAge: 60,
+      onCacheEvent: (e) => events.push(e),
+    });
+
+    await handler({ req: new Request("http://localhost/products?color=red") });
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.every((e) => e.name === "/products?color=red")).toBe(true);
+  });
+
+  it("routes a throwing hook to onError without breaking caching", async () => {
+    const onError = vi.fn();
+    const fn = defineCachedFunction(() => "v1", {
+      maxAge: 60,
+      getKey: () => "k",
+      onCacheEvent: () => {
+        throw new Error("hook failed");
+      },
+      onError,
+    });
+
+    expect(await fn()).toBe("v1");
+    expect(await fn()).toBe("v1");
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("exposes CacheEventType constants matching the emitted event types", async () => {
+    expect(CacheEventType).toMatchObject({
+      Hit: "hit",
+      Miss: "miss",
+      Stale: "stale",
+      Set: "set",
+      Evict: "evict",
+    });
+
+    const events: CacheEvent[] = [];
+    const fn = defineCachedFunction(() => "v1", {
+      maxAge: 60,
+      getKey: () => "k",
+      onCacheEvent: (e) => events.push(e),
+    });
+
+    await fn();
+
+    // Constants compare equal to the raw discriminant string.
+    expect(events.some((e) => e.type === CacheEventType.Miss)).toBe(true);
+    expect(events.some((e) => e.type === CacheEventType.Set)).toBe(true);
+  });
+
+  it("does not evaluate validate eagerly on the no-hook path (short-circuit preserved)", async () => {
+    let validateCalls = 0;
+    const fn = defineCachedFunction(() => "v1", {
+      maxAge: 60,
+      swr: false,
+      getKey: () => "k",
+      validate: (entry) => {
+        validateCalls++;
+        return entry.value !== undefined;
+      },
+    });
+
+    await fn();
+
+    // On a miss the `expired` check short-circuits before validate; only the post-resolve
+    // write path validates. Eager evaluation would push this to 2.
+    expect(validateCalls).toBe(1);
+  });
+
+  it("does not emit evict when invalidating a key that was never cached", async () => {
+    const events: CacheEvent[] = [];
+    const fn = defineCachedFunction(() => "v1", {
+      maxAge: 60,
+      getKey: () => "k",
+      onCacheEvent: (e) => events.push(e),
+    });
+
+    await fn.invalidate();
+
+    expect(events.filter((e) => e.type === "evict")).toHaveLength(0);
+  });
+
+  it("reports reason 'initial' (not 'maxAge') when a fully-expired entry is repopulated", async () => {
+    const events: CacheEvent[] = [];
+    let n = 0;
+    const fn = defineCachedFunction(() => `v${++n}`, {
+      maxAge: 0.05,
+      swr: true,
+      staleMaxAge: 0.05,
+      getKey: () => "k",
+      onCacheEvent: (e) => events.push(e),
+    });
+
+    await fn();
+    const [storageKey] = await fn.resolveKeys();
+    const stored = (await useStorage().get(storageKey!)) as object;
+    // Backdate mtime beyond maxAge + staleMaxAge so the entry is fully expired but still present.
+    await useStorage().set(storageKey!, { ...stored, mtime: Date.now() - 10_000 });
+    events.length = 0;
+
+    await fn();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(events[0]).toMatchObject({ type: "miss" });
+    const set = events.filter((e) => e.type === "set").at(-1) as Extract<
+      CacheEvent,
+      { type: "set" }
+    >;
+    expect(set).toMatchObject({ oldValue: undefined, reason: "initial" });
+  });
+
+  it("emits set(manual) when shouldInvalidateCache forces a re-resolve", async () => {
+    const events: CacheEvent[] = [];
+    let n = 0;
+    let invalidate = false;
+    const fn = defineCachedFunction(() => `v${++n}`, {
+      maxAge: 60,
+      swr: false,
+      name: "myFn",
+      getKey: () => "k",
+      shouldInvalidateCache: () => invalidate,
+      onCacheEvent: (e) => events.push(e),
+    });
+
+    await fn();
+    invalidate = true;
+    await fn();
+
+    const set = events.filter((e) => e.type === "set").at(-1) as Extract<
+      CacheEvent,
+      { type: "set" }
+    >;
+    expect(set).toMatchObject({ name: "myFn", oldValue: "v1", newValue: "v2", reason: "manual" });
+  });
+
+  it("routes a throwing hook during invalidate to onError", async () => {
+    const onError = vi.fn();
+    const fn = defineCachedFunction(() => "v1", {
+      maxAge: 60,
+      getKey: () => "k",
+      onCacheEvent: (e) => {
+        if (e.type === "evict") throw new Error("hook failed");
+      },
+      onError,
+    });
+
+    await fn();
+    await fn.invalidate();
+
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("still removes entries (and routes to onError) when the oldValue read fails on invalidate", async () => {
+    const deleted: string[] = [];
+    const onError = vi.fn();
+    setStorage({
+      get: () => {
+        throw new Error("read boom");
+      },
+      set: (key, value) => {
+        if (value === null || value === undefined) {
+          deleted.push(key);
+        }
+      },
+    });
+
+    await invalidateCache({
+      options: { name: "n", getKey: () => "k", onCacheEvent: () => {}, onError },
+    });
+
+    // Removal must proceed even though the pre-read rejected.
+    expect(deleted.length).toBeGreaterThan(0);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("adding onCacheEvent does not change integrity, so existing entries stay valid", async () => {
+    let calls = 0;
+    const impl = () => {
+      calls++;
+      return "value";
+    };
+    const shared = { maxAge: 60, name: "shared", getKey: () => "k" };
+
+    const fnNoHook = defineCachedFunction(impl, shared);
+    await fnNoHook();
+    expect(calls).toBe(1);
+
+    // Same function + options with only onCacheEvent added: must reuse the cached entry.
+    const fnHook = defineCachedFunction(impl, { ...shared, onCacheEvent: () => {} });
+    expect(await fnHook()).toBe("value");
+    expect(calls).toBe(1);
   });
 });


### PR DESCRIPTION
Adds an opt-in onCacheEvent hook for observing the cache lifecycle. Closes #19 and #13.

What it does
- One onCacheEvent(event) hook on defineCachedFunction / defineCachedHandler emitting a typed union: hit · miss · stale · set · evict.
- set carries oldValue / newValue / reason (initial · maxAge · stale · invalid · manual); evict carries oldValue / reason (error · invalid · manual) — covers #19's update/eviction callback.
- Each event has key (logical cache key) and name (function name, or request route for HTTP handlers) — enables the human-readable dev logging asked for in #13.
- Event types are exported as CacheEventType constants (CacheEventType.Hit …) so consumers can avoid string literals; values are plain strings, so event.type === "hit" still works.
- Logging stays the caller's responsibility: no built-in logger, just a documented snippet in the README.
- No behavior change when unused — with no hook set, the path is identical to before (validate keeps its short-circuit; no extra reads, URL parses, or allocations). Regression-tested.
- Excluded from the integrity hash, so adding/removing the hook never invalidates existing cache entries. Tested.
- Hook errors route to onError and never affect caching.

Tests: new cases covering every event type and reason, HTTP route naming, CacheEventType constants, hook-error isolation on both the get and invalidate paths, and regression guards (no-op invalidate emits nothing, fully-expired repopulation reports initial, no eager validate on the no-hook path, integrity unchanged when the hook is added). Full suite 115 passing; lint, typecheck, and build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache lifecycle event hooks so apps can react to cache hits, misses, stale responses, updates, and evictions.
  * Added typed event details and reason values for safer handling in application code.
  * Re-exported the new cache event types for easier access.

* **Bug Fixes**
  * Improved cache invalidation and refresh behavior to report the correct event reasons.
  * Kept cache integrity checks stable when event hooks are enabled.

* **Documentation**
  * Updated the README with examples and API details for the new cache event support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->