### PR TITLE
feat(cache): support dynamic per-entry TTL via `getMaxAge` hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Never touch contents inside `<!-- automd -->` in README.md. They are auto genera
 ### Core caching (`cache.ts`)
 
 - `defineCachedFunction(fn, opts)` — wraps any function with caching (SWR, TTL, integrity checks, deduplication of in-flight requests)
+- `getMaxAge(entry)` option — dynamic per-entry TTL: runs after the resolver, returns a number (seconds, shorthand for `maxAge`) or `{ maxAge?, staleMaxAge? }` that override the static options for that entry. Resolved values are persisted on the entry (`CacheEntry.maxAge` / `CacheEntry.staleMaxAge`) and drive both the read freshness check and the storage TTL. Absent field / `undefined` → falls back to static options. Flows through to `defineCachedHandler` (entry value is the `ResponseCacheEntry`)
 - `cachedFunction(fn, opts)` — alias for `defineCachedFunction`
 - Returned cached function has `.resolveKeys(...args)`, `.invalidate(...args)`, and `.expire(...args)` methods
 - `resolveCacheKeys({ options, args })` — standalone helper to resolve storage keys
@@ -52,7 +53,7 @@ Never touch contents inside `<!-- automd -->` in README.md. They are auto genera
 - `HTTPEvent` — `{ req: Request; url?: URL }` (url falls back to `new URL(req.url)`)
 - `EventHandler<E>` — `(event: E) => unknown | Promise<unknown>` (generic, defaults to HTTPEvent)
 - `CacheEntry<T>` — stored cache entry with value, expires, mtime, integrity
-- `CacheOptions<T>` — maxAge, swr, staleMaxAge, base (string | string[] for multi-tier), getKey, validate, transform, etc.
+- `CacheOptions<T>` — maxAge, swr, staleMaxAge, getMaxAge (dynamic per-entry TTL hook), base (string | string[] for multi-tier), getKey, validate, transform, etc.
 - `CachedEventHandlerOptions<E>` — extends CacheOptions with headersOnly, varies, toResponse, createResponse, handleCacheHeaders
 - `CacheConditions` — `{ modifiedTime?, maxAge?, etag? }` passed to handleCacheHeaders hook
 - `ResponseCacheEntry` — serialized response (status, statusText, headers, body)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ const cached = defineCachedFunction(fn, {
   maxAge: 10, // TTL in seconds (default: 1)
   swr: true, // Stale-while-revalidate (default: true)
   staleMaxAge: 60, // Max seconds to serve stale content
+  getMaxAge: (entry) => entry.value?.expires_in, // Per-entry TTL from the resolved value
   base: "/cache", // Base prefix for cache keys (string or string[] for multi-tier)
   group: "my-group", // Cache key group (default: "functions")
   getKey: (...args) => "custom-key", // Custom cache key generator
@@ -48,6 +49,20 @@ const cached = defineCachedFunction(fn, {
   transform: (entry) => entry.value, // Transform before returning
   onError: (error) => console.error(error), // Error handler
 });
+```
+
+#### Dynamic TTL
+
+Some cached values carry their own expiry — an OAuth token with `expires_in`, an upstream response with `Cache-Control: max-age`. Use `getMaxAge` to derive the lifetime from the resolved value instead of a fixed constant. It runs after the resolver and returns either a number (seconds, shorthand for `maxAge`) or `{ maxAge?, staleMaxAge? }` to also override the stale window. The resolved values override the static options for that entry and are used for both the freshness check and the storage TTL. Return `undefined` (or omit a field) to fall back to the static option.
+
+```ts
+const getToken = defineCachedFunction(
+  () => fetchToken(), // resolves { access_token, expires_in }
+  {
+    // Cache each token for exactly its own lifetime (minus a small safety margin)
+    getMaxAge: (entry) => (entry.value?.expires_in ?? 60) - 5,
+  },
+);
 ```
 
 ### Caching HTTP Handlers

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const getToken = defineCachedFunction(
   () => fetchToken(), // resolves { access_token, expires_in }
   {
     // Cache each token for exactly its own lifetime (minus a small safety margin)
-    getMaxAge: (entry) => (entry.value?.expires_in ?? 60) - 5,
+    getMaxAge: (entry) => Math.max(1, (entry.value?.expires_in ?? 60) - 5),
   },
 );
 ```

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -162,8 +162,10 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
             const resolved = await opts.getMaxAge(entry);
             // A bare number is shorthand for `{ maxAge }`.
             const dynamic = typeof resolved === "number" ? { maxAge: resolved } : resolved;
-            entry.maxAge = dynamic?.maxAge;
-            entry.staleMaxAge = dynamic?.staleMaxAge;
+            // Clamp to a non-negative TTL: a value <= 0 means "don't cache" (re-resolve every
+            // access), never "cache forever as fresh". Non-finite (NaN) falls back to static options.
+            entry.maxAge = _clampTtl(dynamic?.maxAge);
+            entry.staleMaxAge = _clampTtl(dynamic?.staleMaxAge);
           } catch (error) {
             _onError("[cache] getMaxAge hook error.", error);
           }
@@ -374,6 +376,11 @@ export async function expireCache<ArgsT extends unknown[] = any[]>(
 
 function isHTTPEvent(input: unknown): input is HTTPEvent {
   return (input as any)?.req instanceof Request;
+}
+
+/** Normalizes a dynamic TTL: clamps negatives to 0, treats nullish/non-finite as "unset" (static fallback). */
+function _clampTtl(value: number | undefined): number | undefined {
+  return value == null || !Number.isFinite(value) ? undefined : Math.max(0, value);
 }
 
 function getKey(...args: unknown[]) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -87,14 +87,18 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       _onError("[cache]", error);
     }
 
-    const ttl = (opts.maxAge ?? 0) * 1000;
+    // Per-entry TTL (set by the `getMaxAge` hook on the previous write) takes precedence over static options.
+    const readMaxAge = entry.maxAge ?? opts.maxAge;
+    const readStaleMaxAge = entry.staleMaxAge ?? opts.staleMaxAge;
+
+    const ttl = (readMaxAge ?? 0) * 1000;
     if (ttl > 0) {
       entry.expires = Date.now() + ttl;
     }
 
     const staleTtl =
-      opts.swr && opts.staleMaxAge != null && opts.staleMaxAge >= 0
-        ? opts.staleMaxAge * 1000
+      opts.swr && readStaleMaxAge != null && readStaleMaxAge >= 0
+        ? readStaleMaxAge * 1000
         : undefined;
 
     // When staleMaxAge is set, an entry is completely dead after maxAge + staleMaxAge
@@ -105,7 +109,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       shouldInvalidateCache ||
       entry.stale === true ||
       entry.integrity !== integrity ||
-      opts.maxAge === 0 ||
+      readMaxAge === 0 ||
       (ttl > 0 && Date.now() - (entry.mtime || 0) > ttl) ||
       validate(entry) === false;
 
@@ -152,17 +156,32 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
         entry.integrity = integrity;
         entry.stale = undefined;
         delete pending[key];
+        // Derive per-entry lifetime from the resolved value, overriding static options for this write.
+        if (opts.getMaxAge) {
+          try {
+            const resolved = await opts.getMaxAge(entry);
+            // A bare number is shorthand for `{ maxAge }`.
+            const dynamic = typeof resolved === "number" ? { maxAge: resolved } : resolved;
+            entry.maxAge = dynamic?.maxAge;
+            entry.staleMaxAge = dynamic?.staleMaxAge;
+          } catch (error) {
+            _onError("[cache] getMaxAge hook error.", error);
+          }
+        }
         if (validate(entry) !== false) {
+          // Per-entry TTL (from the `getMaxAge` hook) falls back to static options when not provided.
+          const writeMaxAge = entry.maxAge ?? opts.maxAge;
+          const writeStaleMaxAge = entry.staleMaxAge ?? opts.staleMaxAge;
           let setOpts: { ttl?: number } | undefined;
-          if (opts.maxAge != null && opts.maxAge > 0) {
+          if (writeMaxAge != null && writeMaxAge > 0) {
             if (opts.swr) {
               // With SWR, storage TTL must cover maxAge + staleMaxAge window
-              if (opts.staleMaxAge != null && opts.staleMaxAge >= 0) {
-                setOpts = { ttl: opts.maxAge + opts.staleMaxAge };
+              if (writeStaleMaxAge != null && writeStaleMaxAge >= 0) {
+                setOpts = { ttl: writeMaxAge + writeStaleMaxAge };
               }
               // If staleMaxAge is not set, no storage TTL (entry lives until manually evicted)
             } else {
-              setOpts = { ttl: opts.maxAge };
+              setOpts = { ttl: writeMaxAge };
             }
           }
           // Multi-tier write: only write to tiers up to the one that matched.
@@ -387,15 +406,18 @@ function _remainingTtl(
   entry: CacheEntry,
   opts: Pick<CacheOptions, "maxAge" | "swr" | "staleMaxAge">,
 ): { ttl: number } | undefined {
-  if (!entry.mtime || opts.maxAge == null || opts.maxAge <= 0) {
+  // Prefer the per-entry TTL persisted by `getMaxAge`, falling back to static options.
+  const maxAge = entry.maxAge ?? opts.maxAge;
+  const staleMaxAge = entry.staleMaxAge ?? opts.staleMaxAge;
+  if (!entry.mtime || maxAge == null || maxAge <= 0) {
     return undefined;
   }
   // Mirrors the TTL window used on cache writes (see `get` in defineCachedFunction)
   const ttlWindow =
     opts.swr === false
-      ? opts.maxAge
-      : opts.staleMaxAge != null && opts.staleMaxAge >= 0
-        ? opts.maxAge + opts.staleMaxAge
+      ? maxAge
+      : staleMaxAge != null && staleMaxAge >= 0
+        ? maxAge + staleMaxAge
         : undefined;
   if (ttlWindow === undefined) {
     return undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,8 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
    * the entry is persisted. Return a number (seconds) as shorthand for `maxAge`, or an object to also
    * override `staleMaxAge`. The resolved values override the static options for that entry and drive
    * both the read freshness check and the storage TTL. Return `undefined` (or omit a field) to fall
-   * back to the static option.
+   * back to the static option. A resolved value `<= 0` disables caching for that entry (re-resolves
+   * on every access); negatives are clamped to `0` rather than treated as "cache forever".
    *
    * @example
    * ```ts

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,10 @@ export interface CacheEntry<T = any> {
   integrity?: string;
   /** When `true`, the entry is treated as expired on next access (set by `expireCache`). Cleared after a successful revalidation. */
   stale?: boolean;
+  /** Resolved per-entry `maxAge` (seconds) set by the `getMaxAge` hook. Overrides `CacheOptions.maxAge` for this entry's freshness check and storage TTL. */
+  maxAge?: number;
+  /** Resolved per-entry `staleMaxAge` (seconds) set by the `getMaxAge` hook. Overrides `CacheOptions.staleMaxAge` for this entry. */
+  staleMaxAge?: number;
 }
 
 /**
@@ -66,6 +70,28 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
   swr?: boolean;
   /** Maximum number of seconds a stale entry can be served while revalidating. */
   staleMaxAge?: number;
+  /**
+   * Derive the per-entry cache lifetime from the resolved value. Runs after the resolver and before
+   * the entry is persisted. Return a number (seconds) as shorthand for `maxAge`, or an object to also
+   * override `staleMaxAge`. The resolved values override the static options for that entry and drive
+   * both the read freshness check and the storage TTL. Return `undefined` (or omit a field) to fall
+   * back to the static option.
+   *
+   * @example
+   * ```ts
+   * // Cache an OAuth token for exactly its `expires_in`
+   * getMaxAge: (entry) => entry.value?.expires_in,
+   * // Override both the fresh and stale windows
+   * getMaxAge: (entry) => ({ maxAge: 60, staleMaxAge: 300 }),
+   * ```
+   */
+  getMaxAge?: (
+    entry: CacheEntry<T>,
+  ) =>
+    | number
+    | { maxAge?: number; staleMaxAge?: number }
+    | undefined
+    | Promise<number | { maxAge?: number; staleMaxAge?: number } | undefined>;
   /** Base path prefix(es) for cache keys. When an array, reads try each prefix in order (multi-tier) and writes go to all prefixes. Defaults to `"/cache"`. */
   base?: string | string[];
   /** Optional error handler called for all cache-related errors (read, write, SWR, malformed data). */

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -645,6 +645,151 @@ describe("cachedFunction", () => {
   });
 });
 
+describe("getMaxAge (dynamic per-entry TTL)", () => {
+  it("derives maxAge from the resolved value for the freshness check", async () => {
+    let callCount = 0;
+    const fn = defineCachedFunction(
+      () => {
+        callCount++;
+        // First resolve is short-lived, later resolves long-lived
+        return { value: `v${callCount}`, expiresIn: callCount === 1 ? 0.01 : 10 };
+      },
+      {
+        swr: false,
+        getKey: () => "dyn-key",
+        // Number shorthand for maxAge
+        getMaxAge: (entry) => entry.value?.expiresIn,
+      },
+    );
+
+    expect((await fn()).value).toBe("v1");
+    expect(callCount).toBe(1);
+
+    // Within the per-entry maxAge (0.01s) — served from cache
+    expect((await fn()).value).toBe("v1");
+    expect(callCount).toBe(1);
+
+    // Wait past the first entry's short maxAge — re-resolves
+    await new Promise((r) => setTimeout(r, 20));
+    expect((await fn()).value).toBe("v2");
+    expect(callCount).toBe(2);
+
+    // Second entry has a long maxAge — stays cached past the first entry's window
+    await new Promise((r) => setTimeout(r, 20));
+    expect((await fn()).value).toBe("v2");
+    expect(callCount).toBe(2);
+  });
+
+  it("persists the resolved TTL on the stored entry", async () => {
+    const fn = defineCachedFunction(() => ({ n: 1 }), {
+      maxAge: 5,
+      getKey: () => "persist-key",
+      getMaxAge: () => ({ maxAge: 42, staleMaxAge: 7 }),
+    });
+
+    await fn();
+
+    const keys = await fn.resolveKeys();
+    const entry = (await useStorage().get(keys[0]!)) as any;
+    expect(entry.maxAge).toBe(42);
+    expect(entry.staleMaxAge).toBe(7);
+  });
+
+  it("falls back to static options when getMaxAge returns undefined", async () => {
+    let callCount = 0;
+    const fn = defineCachedFunction(
+      () => {
+        callCount++;
+        return callCount;
+      },
+      {
+        maxAge: 10,
+        swr: false,
+        getKey: () => "fallback-key",
+        getMaxAge: () => undefined,
+      },
+    );
+
+    expect(await fn()).toBe(1);
+    // Static maxAge of 10s still applies — served from cache
+    expect(await fn()).toBe(1);
+    expect(callCount).toBe(1);
+
+    const keys = await fn.resolveKeys();
+    const entry = (await useStorage().get(keys[0]!)) as any;
+    expect(entry.maxAge).toBeUndefined();
+  });
+
+  it("uses the per-entry stale window for SWR", async () => {
+    let callCount = 0;
+    const fn = defineCachedFunction(
+      async () => {
+        callCount++;
+        await new Promise((r) => setTimeout(r, 5));
+        return `v${callCount}`;
+      },
+      {
+        swr: true,
+        getKey: () => "swr-dyn-key",
+        getMaxAge: () => ({ maxAge: 0.01, staleMaxAge: 10 }),
+      },
+    );
+
+    expect(await fn()).toBe("v1");
+    expect(callCount).toBe(1);
+
+    // Past per-entry maxAge but within staleMaxAge — serves stale, revalidates in background
+    await new Promise((r) => setTimeout(r, 15));
+    expect(await fn()).toBe("v1");
+    expect(callCount).toBe(2);
+  });
+
+  it("continues writing the entry when getMaxAge throws (reports via onError)", async () => {
+    const errors: unknown[] = [];
+    let callCount = 0;
+    const fn = defineCachedFunction(
+      () => {
+        callCount++;
+        return callCount;
+      },
+      {
+        maxAge: 10,
+        swr: false,
+        getKey: () => "throw-key",
+        getMaxAge: () => {
+          throw new Error("boom");
+        },
+        onError: (e) => errors.push(e),
+      },
+    );
+
+    expect(await fn()).toBe(1);
+    // getMaxAge threw, but the entry is still cached using static options
+    expect(await fn()).toBe(1);
+    expect(callCount).toBe(1);
+    expect(errors.length).toBe(1);
+  });
+
+  it("respects per-entry TTL when expiring via expireCache", async () => {
+    const options = {
+      swr: true,
+      getKey: () => "expire-dyn-key",
+      getMaxAge: () => ({ maxAge: 60, staleMaxAge: 120 }),
+    };
+    const fn = defineCachedFunction(() => "value", options);
+
+    await fn();
+    const keys = await fn.resolveKeys();
+    expect(((await useStorage().get(keys[0]!)) as any).stale).toBeUndefined();
+
+    await expireCache({ options, args: [] });
+    const entry = (await useStorage().get(keys[0]!)) as any;
+    expect(entry.stale).toBe(true);
+    // Entry value is preserved for SWR to keep serving
+    expect(entry.value).toBe("value");
+  });
+});
+
 describe("storage", () => {
   it("createMemoryStorage handles TTL expiry", async () => {
     const storage = createMemoryStorage();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -770,6 +770,31 @@ describe("getMaxAge (dynamic per-entry TTL)", () => {
     expect(errors.length).toBe(1);
   });
 
+  it("clamps a negative maxAge to 0 (re-resolves every access, never cached forever)", async () => {
+    let callCount = 0;
+    const fn = defineCachedFunction(
+      () => {
+        callCount++;
+        return callCount;
+      },
+      {
+        maxAge: 10,
+        swr: false,
+        getKey: () => "negative-key",
+        // A negative TTL (e.g. an already-expired token) must not pin the entry as fresh
+        getMaxAge: () => -5,
+      },
+    );
+
+    expect(await fn()).toBe(1);
+    expect(await fn()).toBe(2);
+    expect(callCount).toBe(2);
+
+    const keys = await fn.resolveKeys();
+    const entry = (await useStorage().get(keys[0]!)) as any;
+    expect(entry.maxAge).toBe(0);
+  });
+
   it("respects per-entry TTL when expiring via expireCache", async () => {
     const options = {
       swr: true,


### PR DESCRIPTION
Closes #36.

## Summary

TTL was fixed at creation time (`maxAge` / `staleMaxAge`). This adds a `getMaxAge` hook that derives an entry's lifetime from the value it resolved to, so the cache can honor per-entry expiry instead of a single global constant.

```ts
const getToken = defineCachedFunction(() => fetchToken(), {
  // cache each token for exactly its own lifetime (number shorthand for maxAge)
  getMaxAge: (entry) => entry.value?.expires_in,
});
```

Motivating cases: OAuth/API tokens with `expires_in`, upstream responses carrying their own `Cache-Control: max-age`, or content-derived freshness.

## How it works

- `getMaxAge?: (entry) => number | { maxAge?, staleMaxAge? } | undefined` runs **after** the resolver, before the entry is persisted (async-supported).
- A bare **number** is shorthand for `{ maxAge }`; return an object to also override the stale window.
- The resolved values are stored on the entry (`CacheEntry.maxAge` / `CacheEntry.staleMaxAge`) and used for **both** the read-side freshness check (including the SWR stale window) and the storage TTL on write.
- Missing field / `undefined` return → falls back to the static option. If the hook throws, the entry is still cached with static options and the error is reported via `onError`.
- `expireCache()` prefers the per-entry TTL when computing the remaining storage window.
- Flows through to `defineCachedHandler` automatically (entry value is the `ResponseCacheEntry`).

## Compatibility

Additive and fully backwards compatible — when `getMaxAge` is absent, behavior is unchanged.

## Tests

New `getMaxAge` block covering: number-shorthand freshness derived from the value, persistence on the stored entry, fallback when the hook returns `undefined`, per-entry SWR stale window, hook-throws resilience, and `expireCache` respecting per-entry TTL. All 105 tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)