### PR TITLE
feat: per-call cache status and `x-cache` response header

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,22 @@ Alias for [`defineCachedFunction`](#definecachedfunction).
 
 ---
 
+### `CacheStatus`
+
+```ts
+type CacheStatus = "hit" | "stale" | "revalidated" | "miss";
+```
+
+How a cached value was served on a given call.
+
+- `"hit"` — a fresh cached value was returned without re-resolving.
+- `"stale"` — a stale value was served while a background SWR refresh runs.
+- `"revalidated"` — a prior value existed but was expired/invalid, so it was
+  re-resolved in the foreground (no stale value served) before returning.
+- `"miss"` — the value was resolved fresh on this call (nothing was cached).
+
+---
+
 ### `createMemoryStorage`
 
 ```ts

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,7 +1,7 @@
 import { hash } from "ohash";
 import { useStorage } from "./storage.ts";
 
-import type { HTTPEvent, CacheEntry, CacheOptions } from "./types.ts";
+import type { HTTPEvent, CacheEntry, CacheOptions, CacheStatus } from "./types.ts";
 
 function defaultCacheOptions() {
   return {
@@ -12,7 +12,7 @@ function defaultCacheOptions() {
   } as const;
 }
 
-type ResolvedCacheEntry<T> = CacheEntry<T> & { value: T };
+type ResolvedCacheEntry<T> = CacheEntry<T> & { value: T; status: CacheStatus };
 
 export type CachedFunction<T, ArgsT extends unknown[]> = {
   (...args: ArgsT): Promise<T>;
@@ -85,6 +85,13 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       entry = {};
       const error = new Error("Malformed data read from cache.");
       _onError("[cache]", error);
+    } else {
+      // Work on a per-call shallow clone: a storage backend may return the entry by
+      // reference (the built-in memory storage does), so all subsequent in-place
+      // mutations below — freshness resets, the `status` attach, the SWR value
+      // refresh — must not corrupt the object still held in storage or let
+      // concurrent same-key calls overwrite each other's per-call fields.
+      entry = { ...entry };
     }
 
     // Per-entry TTL (set by the `getMaxAge` hook on the previous write) takes precedence over static options.
@@ -105,13 +112,17 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
     const isFullyExpired =
       staleTtl !== undefined && ttl > 0 && Date.now() - (entry.mtime || 0) > ttl + staleTtl;
 
+    // Computed once and reused for both the `expired` check and the `status`
+    // decision below (same entry state, so re-validating would just repeat work).
+    const _isValid = validate(entry) !== false;
+
     const expired =
       shouldInvalidateCache ||
       entry.stale === true ||
       entry.integrity !== integrity ||
       readMaxAge === 0 ||
       (ttl > 0 && Date.now() - (entry.mtime || 0) > ttl) ||
-      validate(entry) === false;
+      !_isValid;
 
     // If fully expired beyond staleMaxAge, clear the stale value so SWR won't serve it
     if (isFullyExpired) {
@@ -120,6 +131,21 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       entry.mtime = undefined;
       entry.expires = undefined;
     }
+
+    // Determine how this call will be served (mirrors the serve decision below):
+    // - no usable cached value -> resolved fresh (miss)
+    // - fresh cached value -> hit
+    // - expired but served stale under SWR -> stale
+    // - a prior value existed but was expired/invalid and re-resolved in the
+    //   foreground (no stale served) -> revalidated
+    const status: CacheStatus =
+      entry.value === undefined
+        ? "miss"
+        : !expired
+          ? "hit"
+          : opts.swr && _isValid
+            ? "stale"
+            : "revalidated";
 
     const _resolve = async () => {
       const isPending = pending[key];
@@ -190,11 +216,13 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
           // If no tier had a hit (hitIndex === -1), write to all tiers.
           // If tier N matched, write to tiers 0..N (promote upward + refresh hit tier).
           const writeBases = hitIndex < 0 ? bases : bases.slice(0, hitIndex + 1);
+          // `status` is a per-call field — never persist it to storage.
+          const { status: _status, ...toStore } = entry;
           const promise = (async () => {
             try {
               await Promise.all(
                 writeBases.map((b) =>
-                  useStorage().set(_buildCacheKey(key, { group, name }, b), entry, setOpts),
+                  useStorage().set(_buildCacheKey(key, { group, name }, b), toStore, setOpts),
                 ),
               );
             } catch (error) {
@@ -219,6 +247,21 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
     } else if (expired) {
       event?.req.waitUntil?.(_resolvePromise);
     }
+
+    // Attach the per-call `status` to `entry`. `entry` is a per-call clone (see the
+    // read path above), never the object a ref-sharing storage backend still holds,
+    // so this can't corrupt shared state or race with concurrent same-key calls. It's
+    // still marked NON-ENUMERABLE as defence-in-depth so it stays out of every
+    // persistence path (object spreads, JSON/structuredClone). Attaching to the live
+    // clone (rather than a fresh return-time copy) means a synchronous SWR
+    // revalidation that updates `entry.value` in a microtask is reflected in the
+    // returned value.
+    Object.defineProperty(entry, "status", {
+      value: status,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
 
     if (opts.swr && validate(entry) !== false) {
       _resolvePromise.catch((error) => {

--- a/src/http.ts
+++ b/src/http.ts
@@ -16,6 +16,7 @@ function defaultCacheOptions() {
     base: "/cache",
     swr: true,
     maxAge: 1,
+    cacheStatusHeader: true,
   } as const;
 }
 
@@ -51,8 +52,32 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
 
   const _handleCacheHeaders = opts.handleCacheHeaders || _defaultHandleCacheHeaders;
 
+  // CDN-style cache-status header (X-Cache: HIT | MISS | STALE)
+  const _statusHeader =
+    opts.cacheStatusHeader === true
+      ? "x-cache"
+      : typeof opts.cacheStatusHeader === "string" && opts.cacheStatusHeader
+        ? opts.cacheStatusHeader.toLowerCase()
+        : undefined;
+
   const _opts: CacheOptions<ResponseCacheEntry> = {
     ...opts,
+    // Inject the cache-status header into a cloned entry value (never mutating the
+    // stored entry) so it flows through to the final Response headers.
+    transform: _statusHeader
+      ? (entry) => {
+          if (!entry.value) {
+            return;
+          }
+          return {
+            ...entry.value,
+            headers: {
+              ...entry.value.headers,
+              [_statusHeader]: String(entry.status).toUpperCase(),
+            },
+          };
+        }
+      : undefined,
     shouldBypassCache: (event) => {
       return event.req.method !== "GET" && event.req.method !== "HEAD";
     },
@@ -184,7 +209,13 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
         maxAge: opts.maxAge,
       })
     ) {
-      return _createResponse(null, { status: 304 });
+      const statusValue = _statusHeader
+        ? (response.headers[_statusHeader] as string | undefined)
+        : undefined;
+      return _createResponse(null, {
+        status: 304,
+        headers: statusValue === undefined ? undefined : { [_statusHeader!]: statusValue },
+      });
     }
 
     // Send Response

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export type {
   ServerRequest,
   EventHandler,
   CacheEntry,
+  CacheStatus,
   CacheOptions,
   CachedEventHandlerOptions,
   CacheConditions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,17 @@ export type EventHandler<E extends HTTPEvent = HTTPEvent> = (
 ) => unknown | Promise<unknown>;
 
 /**
+ * How a cached value was served on a given call.
+ *
+ * - `"hit"` — a fresh cached value was returned without re-resolving.
+ * - `"stale"` — a stale value was served while a background SWR refresh runs.
+ * - `"revalidated"` — a prior value existed but was expired/invalid, so it was
+ *   re-resolved in the foreground (no stale value served) before returning.
+ * - `"miss"` — the value was resolved fresh on this call (nothing was cached).
+ */
+export type CacheStatus = "hit" | "stale" | "revalidated" | "miss";
+
+/**
  * Stored cache entry wrapping a cached value with metadata.
  */
 export interface CacheEntry<T = any> {
@@ -42,6 +53,14 @@ export interface CacheEntry<T = any> {
   maxAge?: number;
   /** Resolved per-entry `staleMaxAge` (seconds) set by the `getMaxAge` hook. Overrides `CacheOptions.staleMaxAge` for this entry. */
   staleMaxAge?: number;
+  /**
+   * How this value was served on the current call (`"hit"` / `"stale"` / `"revalidated"` / `"miss"`).
+   *
+   * Populated per-call on the entry passed to `transform` — it is **not** persisted
+   * to storage. Read it from `transform` for metrics/observability or to drive
+   * conditional logic. See {@link CacheStatus}.
+   */
+  status?: CacheStatus;
 }
 
 /**
@@ -52,7 +71,12 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
   name?: string;
   /** Custom cache key generator. Receives the same arguments as the cached function. */
   getKey?: (...args: ArgsT) => string | Promise<string>;
-  /** Transform the cached entry before returning. Return value replaces the cached value. */
+  /**
+   * Transform the cached entry before returning. Return value replaces the cached value.
+   *
+   * The passed entry carries `entry.status` (`"hit"` / `"stale"` / `"revalidated"` / `"miss"`) describing
+   * how the value was served on this call — useful for metrics or conditional logic.
+   */
   transform?: (entry: CacheEntry<T>, ...args: ArgsT) => any;
   /** Validate a cache entry. Return `false` to treat the entry as invalid and re-resolve. */
   validate?: (entry: CacheEntry<T>, ...args: ArgsT) => boolean;
@@ -135,6 +159,17 @@ export interface CachedEventHandlerOptions<E extends HTTPEvent = HTTPEvent> exte
   headersOnly?: boolean;
   /** Request header names that should vary the cache key (e.g., `["accept-language"]`). */
   varies?: string[] | readonly string[];
+
+  /**
+   * Add a cache-status response header (CDN-style `X-Cache: HIT | STALE | REVALIDATED | MISS`).
+   *
+   * - `true` (default) — sets the `X-Cache` header.
+   * - a string — sets a custom header name (e.g. `"x-nitro-cache"`).
+   * - `false` — no header is set.
+   *
+   * Has no effect in `headersOnly` mode (no value is cached there).
+   */
+  cacheStatusHeader?: boolean | string;
 
   /**
    * Convert handler return value to a Response.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -90,6 +90,72 @@ describe("cachedFunction", () => {
     expect(await fn()).toBe("transformed-raw");
   });
 
+  it("exposes cache status (hit/miss/stale) to transform", async () => {
+    const statuses: (string | undefined)[] = [];
+    let n = 0;
+    const fn = defineCachedFunction(() => `v${++n}`, {
+      maxAge: 100,
+      getKey: () => "k",
+      transform: (entry) => {
+        statuses.push(entry.status);
+        return entry.value;
+      },
+    });
+
+    await fn(); // resolved fresh
+    await fn(); // served from cache
+    await fn.expire(); // mark stale for background refresh
+    await fn(); // served stale under SWR
+
+    expect(statuses).toEqual(["miss", "hit", "stale"]);
+  });
+
+  it("reports revalidated when an expired entry is re-resolved in the foreground (swr disabled)", async () => {
+    const statuses: (string | undefined)[] = [];
+    let n = 0;
+    const fn = defineCachedFunction(() => `v${++n}`, {
+      maxAge: 100,
+      swr: false,
+      getKey: () => "k",
+      transform: (entry) => {
+        statuses.push(entry.status);
+        return entry.value;
+      },
+    });
+
+    await fn(); // nothing cached -> miss
+    await fn(); // fresh cached value -> hit
+    await fn.expire(); // mark the existing entry stale
+    await fn(); // no SWR -> prior value re-resolved in foreground -> revalidated
+
+    expect(statuses).toEqual(["miss", "hit", "revalidated"]);
+  });
+
+  it("does not persist per-call status to storage (incl. on a hit)", async () => {
+    const fn = defineCachedFunction(() => "v", { maxAge: 100, getKey: () => "k" });
+    await fn(); // miss (writes entry)
+    await fn(); // hit — must not mutate the stored entry with `status`
+    const [key] = await resolveCacheKeys({ options: { getKey: () => "k" } });
+    const stored = (await useStorage().get(key!)) as Record<string, unknown>;
+    expect(Object.keys(stored)).not.toContain("status");
+  });
+
+  it("does not persist status through expireCache", async () => {
+    const fn = defineCachedFunction(() => "v", {
+      maxAge: 100,
+      staleMaxAge: 100,
+      swr: true,
+      getKey: () => "k",
+    });
+    await fn(); // miss
+    await fn(); // hit (sets per-call status on the returned entry)
+    await fn.expire();
+    const [key] = await resolveCacheKeys({ options: { getKey: () => "k" } });
+    const stored = (await useStorage().get(key!)) as Record<string, unknown>;
+    expect(stored.stale).toBe(true);
+    expect(Object.keys(stored)).not.toContain("status");
+  });
+
   it("handles resolver errors", async () => {
     const fn = defineCachedFunction(
       () => {
@@ -977,6 +1043,70 @@ describe("defineCachedHandler", () => {
     expect(callCount).toBe(1);
   });
 
+  it("sets X-Cache header (MISS then HIT) when cacheStatusHeader is true", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(() => new Response("ok"), {
+      maxAge: 100,
+      cacheStatusHeader: true,
+    });
+
+    const r1 = (await handler(makeEvent(path))) as Response;
+    const r2 = (await handler(makeEvent(path))) as Response;
+
+    expect(r1.headers.get("x-cache")).toBe("MISS");
+    expect(r2.headers.get("x-cache")).toBe("HIT");
+  });
+
+  it("supports a custom cacheStatusHeader name", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(() => new Response("ok"), {
+      maxAge: 100,
+      cacheStatusHeader: "x-nitro-cache",
+    });
+
+    const r1 = (await handler(makeEvent(path))) as Response;
+    const r2 = (await handler(makeEvent(path))) as Response;
+
+    expect(r1.headers.get("x-nitro-cache")).toBe("MISS");
+    expect(r2.headers.get("x-nitro-cache")).toBe("HIT");
+  });
+
+  it("sets the X-Cache header by default", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(() => new Response("ok"), { maxAge: 100 });
+
+    const r1 = (await handler(makeEvent(path))) as Response;
+    const r2 = (await handler(makeEvent(path))) as Response;
+    expect(r1.headers.get("x-cache")).toBe("MISS");
+    expect(r2.headers.get("x-cache")).toBe("HIT");
+  });
+
+  it("disables the cache-status header when cacheStatusHeader is false", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(() => new Response("ok"), {
+      maxAge: 100,
+      cacheStatusHeader: false,
+    });
+
+    const res = (await handler(makeEvent(path))) as Response;
+    expect(res.headers.get("x-cache")).toBeNull();
+  });
+
+  it("propagates cache-status header on 304 responses", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(() => new Response("ok"), {
+      maxAge: 100,
+      cacheStatusHeader: true,
+    });
+
+    const r1 = (await handler(makeEvent(path))) as Response;
+    const etag = r1.headers.get("etag")!;
+    const r2 = (await handler(makeEvent(path, { headers: { "if-none-match": etag } }))) as Response;
+
+    expect(r2.status).toBe(304);
+    expect(r2.headers.get("x-cache")).toBe("HIT");
+  });
+
   it("bypasses cache for non-GET methods", async () => {
     let callCount = 0;
     const path = uniquePath();
@@ -1382,7 +1512,10 @@ describe("defineCachedHandler", () => {
       makeEvent(path, { headers: { "if-none-match": '"test-etag"' } }),
     )) as Response;
     expect(res.status).toBe(304);
-    expect(createResponse).toHaveBeenCalledWith(null, { status: 304 });
+    expect(createResponse).toHaveBeenCalledWith(null, {
+      status: 304,
+      headers: { "x-cache": "HIT" },
+    });
   });
 
   it("uses custom handleCacheHeaders hook", async () => {


### PR DESCRIPTION
## Summary

Adds per-call cache status tracking and a CDN-style `X-Cache` response header.

### Per-call cache status

- Exposes `entry.status` (`"hit"` / `"stale"` / `"miss"`) to `transform` for metrics/observability, describing how the value was served on the current call.
- Status is attached to the live entry as a **non-enumerable** property, so it's readable by `transform` but never persisted to storage — object spreads (including `expireCache`) and JSON/`structuredClone` serialization all drop it, even for backends (like the built-in memory storage) that return entries by reference.

### `X-Cache` header

- Adds `cacheStatusHeader` to `defineCachedHandler` to emit a CDN-style `X-Cache: HIT | MISS | STALE` header.
- Defaults to `true` (`X-Cache`); pass a string for a custom header name, or `false` to disable.
- Propagated on `304 Not Modified` responses.

### Types

- New `CacheStatus` type exported from the package root.

## Tests

Added coverage for the hit/stale/miss status flow (with and without SWR), non-persistence of `status` (on a hit and through `expireCache`), and the `X-Cache` header (default, custom name, disabled, and on 304).

All 108 tests pass; `tsgo` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache status information for cached values, so responses and transforms can tell whether data was a cache hit, miss, or stale result.
  * Added an optional cache-status response header for cached HTTP handlers, with support for a custom header name.
* **Bug Fixes**
  * Cache status is now included on `304 Not Modified` responses and preserved through cache refresh flows.
  * Cache status is kept out of stored cache data, preventing it from being persisted between requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->