### PR TITLE
feat: support asynchronous validate option

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -114,7 +114,9 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
 
     // Computed once and reused for both the `expired` check and the `status`
     // decision below (same entry state, so re-validating would just repeat work).
-    const _isValid = validate(entry) !== false;
+    // `validate` may be async (e.g. checking the cached value against an external source),
+    // so await it here. A sync return is fine too — `await` on a non-promise is a no-op.
+    const _isValid = (await validate(entry)) !== false;
 
     const expired =
       shouldInvalidateCache ||
@@ -196,7 +198,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
             _onError("[cache] getMaxAge hook error.", error);
           }
         }
-        if (validate(entry) !== false) {
+        if ((await validate(entry)) !== false) {
           // Per-entry TTL (from the `getMaxAge` hook) falls back to static options when not provided.
           const writeMaxAge = entry.maxAge ?? opts.maxAge;
           const writeStaleMaxAge = entry.staleMaxAge ?? opts.staleMaxAge;
@@ -266,7 +268,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       configurable: true,
     });
 
-    if (opts.swr && validate(entry) !== false) {
+    if (opts.swr && (await validate(entry)) !== false) {
       _resolvePromise.catch((error) => {
         _onError("[cache] SWR handler error.", error);
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,8 +78,13 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
    * how the value was served on this call — useful for metrics or conditional logic.
    */
   transform?: (entry: CacheEntry<T>, ...args: ArgsT) => any;
-  /** Validate a cache entry. Return `false` to treat the entry as invalid and re-resolve. */
-  validate?: (entry: CacheEntry<T>, ...args: ArgsT) => boolean;
+  /**
+   * Validate a cache entry. Return `false` (or a Promise resolving to `false`) to treat
+   * the entry as invalid and re-resolve. Asynchronous validation is supported for cases
+   * that need to check the cached value against an external source (e.g. fetching a
+   * signed URL to confirm it is still valid).
+   */
+  validate?: (entry: CacheEntry<T>, ...args: ArgsT) => boolean | Promise<boolean>;
   /** When returns `true`, the cache is invalidated and the function is re-invoked. */
   shouldInvalidateCache?: (...args: ArgsT) => boolean | Promise<boolean>;
   /** When returns `true`, the cache is bypassed entirely and the function is called directly. */

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -231,6 +231,72 @@ describe("cachedFunction", () => {
     expect(r2).toBe(2);
   });
 
+  it("supports asynchronous validate", async () => {
+    // Mirrors issue #32: validate needs to check the cached value against an
+    // external source (e.g. fetching a signed URL to confirm it is still valid).
+    let callCount = 0;
+    let remoteValid = true;
+    const fn = defineCachedFunction(
+      () => {
+        callCount++;
+        return callCount;
+      },
+      {
+        maxAge: 10,
+        swr: false,
+        validate: async (entry) => {
+          // Simulate an async check against a remote source
+          await new Promise((r) => setTimeout(r, 1));
+          return remoteValid && (entry.value ?? 0) > 0;
+        },
+      },
+    );
+
+    // First call resolves fresh (miss)
+    expect(await fn()).toBe(1);
+    // Cached value passes async validation -> served from cache
+    expect(await fn()).toBe(1);
+    expect(callCount).toBe(1);
+
+    // Remote now reports the cached value as invalid -> re-resolve
+    remoteValid = false;
+    expect(await fn()).toBe(2);
+    expect(callCount).toBe(2);
+  });
+
+  it("supports asynchronous validate with SWR", async () => {
+    // When async validate reports the cached value as invalid, the entry is
+    // treated as fully invalid: SWR does NOT serve the stale value (it can't be
+    // trusted), and the call re-resolves in the foreground instead.
+    let callCount = 0;
+    let remoteValid = true;
+    const fn = defineCachedFunction(
+      () => {
+        callCount++;
+        return `v${callCount}`;
+      },
+      {
+        maxAge: 1,
+        staleMaxAge: 10,
+        swr: true,
+        validate: async (entry) => {
+          await new Promise((r) => setTimeout(r, 1));
+          return remoteValid && entry.value !== undefined;
+        },
+      },
+    );
+
+    expect(await fn()).toBe("v1");
+    // Within maxAge, async validate passes -> cache hit
+    expect(await fn()).toBe("v1");
+    expect(callCount).toBe(1);
+
+    // Async validate now reports invalid -> re-resolve in foreground (no stale served)
+    remoteValid = false;
+    expect(await fn()).toBe("v2");
+    expect(callCount).toBe(2);
+  });
+
   it("handles cache read errors gracefully", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     setStorage({


### PR DESCRIPTION
## Summary

Resolves #32.

Allow the `validate` option of `defineCachedFunction` to return a `Promise<boolean>`, so cached values can be validated against an external source before being served — e.g. fetching a signed URL to confirm it is still valid, the use case described in the issue.

## Changes

- **`src/types.ts`** — `CacheOptions.validate` return type widened from `boolean` to `boolean | Promise<boolean>`.
- **`src/cache.ts`** — `await` the `validate` callback at its three call sites: the read-path freshness check (reused for both the `expired` flag and the `status` decision), the post-revalidate write check, and the final SWR return check. The default sync validator stays sync.
- **`test/index.test.ts`** — two new tests covering async `validate` (basic re-resolve when invalid, and SWR behaviour when async validate reports the entry invalid).

## Backward compatibility

Fully backward compatible — synchronous `() => boolean` validators continue to work (await on a non-Promise is a no-op). `CachedEventHandlerOptions` already `Omit`s `validate`, so `defineCachedHandler` is unaffected.

## Behavioural note

SWR semantics are unchanged: when `validate` returns `false` the cached value is treated as untrustworthy, so even with `swr: true` the stale value is **not** served — the call re-resolves in the foreground instead. This mirrors the existing behaviour for sync validators.

## Verification

```
pnpm vitest run test/        # 128 passed
pnpm typecheck   # ok
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cache validation can now be asynchronous, allowing cached values to be checked with promises before reuse.
  * Stale-while-revalidate behavior now respects async validation results when deciding whether to serve cached data or refresh it.

* **Bug Fixes**
  * Cached entries are now correctly rechecked and refreshed when async validation fails.
  * Added test coverage for async validation in both standard and stale-while-revalidate caching flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->