### PR TITLE
feat(cache)!: pass call args to `validate`

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -490,7 +490,9 @@ function _remainingTtl(
 }
 
 /** Strips storage-location fields from opts so integrity only reflects the cached computation. */
-function _integrityOpts(opts: CacheOptions<any, any>): Omit<CacheOptions, "base" | "group" | "name"> {
+function _integrityOpts(
+  opts: CacheOptions<any, any>,
+): Omit<CacheOptions, "base" | "group" | "name"> {
   const { base: _, group: _g, name: _n, ...rest } = opts;
   return rest;
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -55,9 +55,11 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
   async function get(
     key: string,
     resolver: () => T | Promise<T>,
+    args: ArgsT,
     shouldInvalidateCache?: boolean,
     event?: HTTPEvent,
   ): Promise<ResolvedCacheEntry<T>> {
+    const validateCtx = { args };
     // Use extension for key to avoid conflicting with parent namespace (foo/bar and foo/bar/baz)
     const bases = _normalizeBases(opts.base);
 
@@ -122,7 +124,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
     // decision below (same entry state, so re-validating would just repeat work).
     // `validate` may be async (e.g. checking the cached value against an external source),
     // so await it here. A sync return is fine too — `await` on a non-promise is a no-op.
-    const _isValid = (await validate(entry)) !== false;
+    const _isValid = (await validate(entry, validateCtx)) !== false;
 
     const expired =
       shouldInvalidateCache ||
@@ -204,7 +206,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
             _onError("[cache] getMaxAge hook error.", error);
           }
         }
-        if ((await validate(entry)) !== false) {
+        if ((await validate(entry, validateCtx)) !== false) {
           // Per-entry TTL (from the `getMaxAge` hook) falls back to static options when not provided.
           const writeMaxAge = entry.maxAge ?? opts.maxAge;
           const writeStaleMaxAge = entry.staleMaxAge ?? opts.staleMaxAge;
@@ -274,7 +276,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
       configurable: true,
     });
 
-    if (swr && (await validate(entry)) !== false) {
+    if (swr && (await validate(entry, validateCtx)) !== false) {
       _resolvePromise.catch((error) => {
         _onError("[cache] SWR handler error.", error);
       });
@@ -294,6 +296,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = any[]>(
     const entry = await get(
       key,
       () => fn(...args),
+      args,
       shouldInvalidateCache,
       isHTTPEvent(args[0]) ? args[0] : undefined,
     );
@@ -487,7 +490,7 @@ function _remainingTtl(
 }
 
 /** Strips storage-location fields from opts so integrity only reflects the cached computation. */
-function _integrityOpts(opts: CacheOptions): Omit<CacheOptions, "base" | "group" | "name"> {
+function _integrityOpts(opts: CacheOptions<any, any>): Omit<CacheOptions, "base" | "group" | "name"> {
   const { base: _, group: _g, name: _n, ...rest } = opts;
   return rest;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,8 +83,15 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
    * the entry as invalid and re-resolve. Asynchronous validation is supported for cases
    * that need to check the cached value against an external source (e.g. fetching a
    * signed URL to confirm it is still valid).
+   *
+   * The second argument carries the `args` the cached function was called with, so the
+   * entry can be validated against the current call (e.g. comparing a request parameter
+   * against `entry.mtime`).
    */
-  validate?: (entry: CacheEntry<T>, ...args: ArgsT) => boolean | Promise<boolean>;
+  validate?: (
+    entry: CacheEntry<T>,
+    ctx: { args: ArgsT },
+  ) => boolean | Promise<boolean>;
   /** When returns `true`, the cache is invalidated and the function is re-invoked. */
   shouldInvalidateCache?: (...args: ArgsT) => boolean | Promise<boolean>;
   /** When returns `true`, the cache is bypassed entirely and the function is called directly. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,10 +88,7 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
    * entry can be validated against the current call (e.g. comparing a request parameter
    * against `entry.mtime`).
    */
-  validate?: (
-    entry: CacheEntry<T>,
-    ctx: { args: ArgsT },
-  ) => boolean | Promise<boolean>;
+  validate?: (entry: CacheEntry<T>, ctx: { args: ArgsT }) => boolean | Promise<boolean>;
   /** When returns `true`, the cache is invalidated and the function is re-invoked. */
   shouldInvalidateCache?: (...args: ArgsT) => boolean | Promise<boolean>;
   /** When returns `true`, the cache is bypassed entirely and the function is called directly. */

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -231,6 +231,45 @@ describe("cachedFunction", () => {
     expect(r2).toBe(2);
   });
 
+  it("passes call args to validate", async () => {
+    // Regression for nitrojs/nitro#3525: validate must receive the args the cached
+    // function was called with, so an entry can be validated against the current call
+    // (e.g. comparing a request parameter against `entry.mtime`).
+    let callCount = 0;
+    const seenArgs: Array<unknown[]> = [];
+    const fn = defineCachedFunction(
+      (_id: string, lastUpdated: number) => {
+        callCount++;
+        return { callCount, lastUpdated };
+      },
+      {
+        maxAge: 10,
+        swr: false,
+        getKey: (id) => id,
+        validate: (entry, { args }) => {
+          seenArgs.push(args);
+          const [, lastUpdated] = args;
+          // Invalidate the cached entry when the caller reports newer data.
+          return (entry.value?.lastUpdated ?? 0) >= lastUpdated;
+        },
+      },
+    );
+
+    // First call resolves fresh (miss) — validate still runs on the empty read entry.
+    expect(await fn("a", 100)).toEqual({ callCount: 1, lastUpdated: 100 });
+    // Same args -> cached value passes validation.
+    expect(await fn("a", 100)).toEqual({ callCount: 1, lastUpdated: 100 });
+    expect(callCount).toBe(1);
+
+    // A newer `lastUpdated` makes validate return false -> re-resolve.
+    expect(await fn("a", 200)).toEqual({ callCount: 2, lastUpdated: 200 });
+    expect(callCount).toBe(2);
+
+    // validate always saw the args from the current call.
+    expect(seenArgs.every((args) => args.length === 2)).toBe(true);
+    expect(seenArgs.at(-1)).toEqual(["a", 200]);
+  });
+
   it("supports asynchronous validate", async () => {
     // Mirrors issue #32: validate needs to check the cached value against an
     // external source (e.g. fetching a signed URL to confirm it is still valid).


### PR DESCRIPTION
## Context

The `validate` hook's type signature promised the cached function's args:

```ts
validate?: (entry: CacheEntry<T>, ...args: ArgsT) => boolean | Promise<boolean>;
```

...but the implementation only ever called `validate(entry)` — the args came through `undefined`. This surfaced in [nitrojs/nitro#3525](https://github.com/nitrojs/nitro/issues/3525), where a developer wanted to compare an incoming request parameter against the cached `entry.mtime` and found the parameter was always `undefined`. `shouldInvalidateCache` isn't a workaround since it doesn't expose the entry. (See also the related motivation in [nitrojs/nitro#3491](https://github.com/nitrojs/nitro/issues/3491) and upstream fix attempt [nitrojs/nitro#3530](https://github.com/nitrojs/nitro/pull/3530).)

## Change

Thread the cached function's call args through to every `validate(entry)` call site in `cache.ts`, passed as a `{ args }` context object:

```ts
validate?: (entry: CacheEntry<T>, ctx: { args: ArgsT }) => boolean | Promise<boolean>;
```

Using a `{ args }` object (rather than spreading `...args`) keeps the entry as the primary positional argument and leaves room for future context fields without another breaking signature change.

`http.ts`'s built-in validator only reads `entry`, so it is unaffected.

## Tests

Added a regression test asserting `validate` receives the current call's args and can invalidate an entry based on them. All 130 tests pass; typecheck clean.

Closes nitrojs/nitro#3525

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cache validation now has access to the current call’s arguments, making validation decisions more accurate.
  * Cache entries are rechecked using the latest call context, improving behavior when inputs change between calls.
* **Developer Experience**
  * The validation callback now receives a single context object containing the call arguments, with updated documentation to match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->