### PR TITLE
feat(http): support `shouldCache` to reject responses from caching (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ const handler = defineCachedHandler(myHandler, {
 });
 ```
 
-`shouldCache` receives the serialized response entry and the originating event, may be async, and is **ANDed** with the built-in checks — it can only narrow what gets cached, never force-cache a response the built-ins reject.
+`shouldCache` receives the serialized response entry and the event, may be async, and is **ANDed** with the built-in checks — it can only narrow what gets cached, never force-cache a response the built-ins reject. It gates both storing a fresh response and serving a stored one (so base the decision on the response `entry`), and a throwing hook fails closed (treated as non-cacheable) and is reported via `onError`.
 
 ### Cache Invalidation
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ const handler = defineCachedHandler(myHandler, {
 });
 ```
 
-`shouldCache` receives the serialized response entry and the event, may be async, and is **ANDed** with the built-in checks — it can only narrow what gets cached, never force-cache a response the built-ins reject. It gates both storing a fresh response and serving a stored one (so base the decision on the response `entry`), and a throwing hook fails closed (treated as non-cacheable) and is reported via `onError`.
+`shouldCache` receives the serialized response entry, may be async, and is **ANDed** with the built-in checks — it can only narrow what gets cached, never force-cache a response the built-ins reject. It gates both storing a fresh response and serving a stored one, and a throwing hook fails closed (treated as non-cacheable) and is reported via `onError`.
 
 ### Cache Invalidation
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ const handler = defineCachedHandler(myHandler, {
 > [!NOTE]
 > This only governs what is **stored**. Concurrent requests are still coalesced by cache key, so per-user responses must be keyed correctly (e.g. via `varies`) — `no-store` / `private` prevents caching, it does not by itself partition the cache key.
 
+#### Custom cache eligibility (`shouldCache`)
+
+The built-in response validation already rejects `4xx`/`5xx` statuses, `Cache-Control: no-store`/`private`, empty bodies, and responses missing `etag`/`last-modified`. Use `shouldCache` to add your own rejection rule on top — for example to keep `3xx` redirects out of the cache:
+
+```ts
+const handler = defineCachedHandler(myHandler, {
+  maxAge: 60,
+  // Return false to skip caching this response (it is still returned to the caller).
+  shouldCache: (res) => res.status < 300 || res.status >= 400,
+});
+```
+
+`shouldCache` receives the serialized response entry and the originating event, may be async, and is **ANDed** with the built-in checks — it can only narrow what gets cached, never force-cache a response the built-ins reject.
+
 ### Cache Invalidation
 
 Cached functions have an `.invalidate()` method that removes cached entries across all base prefixes:

--- a/src/http.ts
+++ b/src/http.ts
@@ -121,7 +121,7 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
         .map(([name, value]) => `${escapeKey(name as string)}.${hash(value)}`);
       return [_hashedPath, ..._headers].join(":");
     },
-    validate: (entry) => {
+    validate: async (entry, ctx) => {
       if (!entry.value) {
         return false;
       }
@@ -139,6 +139,12 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
         entry.value.headers.etag === "undefined" ||
         entry.value.headers["last-modified"] === "undefined"
       ) {
+        return false;
+      }
+      // Additive user hook: ANDed with the built-in checks above so callers can
+      // reject responses (e.g. redirects) without reimplementing load-bearing
+      // safety checks. Cannot be used to force-cache a response the built-ins reject.
+      if (opts.shouldCache && (await opts.shouldCache(entry.value, ctx.args[0] as E)) === false) {
         return false;
       }
       return true;

--- a/src/http.ts
+++ b/src/http.ts
@@ -144,8 +144,21 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
       // Additive user hook: ANDed with the built-in checks above so callers can
       // reject responses (e.g. redirects) without reimplementing load-bearing
       // safety checks. Cannot be used to force-cache a response the built-ins reject.
-      if (opts.shouldCache && (await opts.shouldCache(entry.value, ctx.args[0] as E)) === false) {
-        return false;
+      // A throwing hook fails closed (treat as not cacheable) rather than breaking
+      // the request — the response is still served, just not stored/served-from-cache.
+      if (opts.shouldCache) {
+        try {
+          if ((await opts.shouldCache(entry.value, ctx.args[0] as E)) === false) {
+            return false;
+          }
+        } catch (error) {
+          if (opts.onError) {
+            opts.onError(error);
+          } else {
+            console.error("[cache] shouldCache hook error.", error);
+          }
+          return false;
+        }
       }
       return true;
     },

--- a/src/http.ts
+++ b/src/http.ts
@@ -121,7 +121,7 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
         .map(([name, value]) => `${escapeKey(name as string)}.${hash(value)}`);
       return [_hashedPath, ..._headers].join(":");
     },
-    validate: async (entry, ctx) => {
+    validate: async (entry) => {
       if (!entry.value) {
         return false;
       }
@@ -148,7 +148,7 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
       // the request — the response is still served, just not stored/served-from-cache.
       if (opts.shouldCache) {
         try {
-          if ((await opts.shouldCache(entry.value, ctx.args[0] as E)) === false) {
+          if ((await opts.shouldCache(entry.value)) === false) {
             return false;
           }
         } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,4 +209,25 @@ export interface CachedEventHandlerOptions<E extends HTTPEvent = HTTPEvent> exte
    * Default: built-in if-none-match / if-modified-since check.
    */
   handleCacheHeaders?: (event: E, conditions: CacheConditions) => boolean;
+
+  /**
+   * Additional predicate deciding whether a handler response should be cached.
+   *
+   * Runs *after* — and in addition to — the built-in response validation, which
+   * always applies and cannot be bypassed (it rejects `4xx`/`5xx` statuses,
+   * `Cache-Control: no-store`/`private`, missing bodies, and absent
+   * `etag`/`last-modified`). Return `false` (or a Promise resolving to `false`)
+   * to skip caching this response; it is still returned to the caller, just not
+   * stored. Receives the serialized response entry and the originating event.
+   *
+   * Because it is ANDed with the built-ins, it can only *narrow* what gets
+   * cached — it cannot force-cache a response the built-in checks reject.
+   *
+   * @example
+   * ```ts
+   * // Don't cache redirects (3xx), which the built-in checks would otherwise allow.
+   * shouldCache: (res) => res.status < 300 || res.status >= 400,
+   * ```
+   */
+  shouldCache?: (entry: ResponseCacheEntry, event: E) => boolean | Promise<boolean>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,17 +218,15 @@ export interface CachedEventHandlerOptions<E extends HTTPEvent = HTTPEvent> exte
    * `Cache-Control: no-store`/`private`, missing bodies, and absent
    * `etag`/`last-modified`). Return `false` (or a Promise resolving to `false`)
    * to treat the response as non-cacheable; it is still returned to the caller,
-   * just not stored. Receives the serialized response entry and the event.
+   * just not stored. Receives the serialized response entry.
    *
    * Because it is ANDed with the built-ins, it can only *narrow* what gets
    * cached — it cannot force-cache a response the built-in checks reject.
    *
    * Note it gates both storing a fresh response **and** serving a stored one, so
    * it also runs on cache reads (including the stale-while-revalidate serve
-   * decision) — prefer basing the decision on the response `entry`, since the
-   * `event` may reflect either the original or the internally header/query-filtered
-   * request depending on the code path. Keep it fast; a throwing hook fails closed
-   * (treated as non-cacheable) and is reported via `onError`.
+   * decision). Keep it fast and pure (decide only from `entry`); a throwing hook
+   * fails closed (treated as non-cacheable) and is reported via `onError`.
    *
    * @example
    * ```ts
@@ -236,5 +234,5 @@ export interface CachedEventHandlerOptions<E extends HTTPEvent = HTTPEvent> exte
    * shouldCache: (res) => res.status < 300 || res.status >= 400,
    * ```
    */
-  shouldCache?: (entry: ResponseCacheEntry, event: E) => boolean | Promise<boolean>;
+  shouldCache?: (entry: ResponseCacheEntry) => boolean | Promise<boolean>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,17 +211,24 @@ export interface CachedEventHandlerOptions<E extends HTTPEvent = HTTPEvent> exte
   handleCacheHeaders?: (event: E, conditions: CacheConditions) => boolean;
 
   /**
-   * Additional predicate deciding whether a handler response should be cached.
+   * Additional predicate deciding whether a handler response is cacheable.
    *
    * Runs *after* — and in addition to — the built-in response validation, which
    * always applies and cannot be bypassed (it rejects `4xx`/`5xx` statuses,
    * `Cache-Control: no-store`/`private`, missing bodies, and absent
    * `etag`/`last-modified`). Return `false` (or a Promise resolving to `false`)
-   * to skip caching this response; it is still returned to the caller, just not
-   * stored. Receives the serialized response entry and the originating event.
+   * to treat the response as non-cacheable; it is still returned to the caller,
+   * just not stored. Receives the serialized response entry and the event.
    *
    * Because it is ANDed with the built-ins, it can only *narrow* what gets
    * cached — it cannot force-cache a response the built-in checks reject.
+   *
+   * Note it gates both storing a fresh response **and** serving a stored one, so
+   * it also runs on cache reads (including the stale-while-revalidate serve
+   * decision) — prefer basing the decision on the response `entry`, since the
+   * `event` may reflect either the original or the internally header/query-filtered
+   * request depending on the code path. Keep it fast; a throwing hook fails closed
+   * (treated as non-cacheable) and is reported via `onError`.
    *
    * @example
    * ```ts

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1365,6 +1365,82 @@ describe("defineCachedHandler", () => {
     expect(callCount).toBe(2);
   });
 
+  it("does not cache responses rejected by shouldCache", async () => {
+    let callCount = 0;
+    const path = uniquePath();
+    const handler = defineCachedHandler(
+      () => {
+        callCount++;
+        // A 3xx redirect passes the built-in checks (status < 400) but the caller
+        // wants to keep it out of the cache.
+        return new Response("", { status: 302, headers: { location: "/elsewhere" } });
+      },
+      { maxAge: 10, shouldCache: (res) => res.status < 300 || res.status >= 400 },
+    );
+
+    await handler(makeEvent(path));
+    await handler(makeEvent(path));
+
+    // Rejected by shouldCache -> never served from cache: handler runs every time.
+    expect(callCount).toBe(2);
+  });
+
+  it("caches responses accepted by shouldCache", async () => {
+    let callCount = 0;
+    const path = uniquePath();
+    const handler = defineCachedHandler(
+      () => {
+        callCount++;
+        return new Response("ok");
+      },
+      { maxAge: 10, shouldCache: (res) => res.status === 200 },
+    );
+
+    const r1 = (await handler(makeEvent(path))) as Response;
+    const r2 = (await handler(makeEvent(path))) as Response;
+
+    expect(await r1.text()).toBe("ok");
+    expect(await r2.text()).toBe("ok");
+    // Accepted by shouldCache -> second request served from cache.
+    expect(callCount).toBe(1);
+    expect(r2.headers.get("x-cache")).toBe("HIT");
+  });
+
+  it("shouldCache receives the response entry and event, and supports async", async () => {
+    const seen: Array<{ status: number; url: string }> = [];
+    const path = uniquePath();
+    const handler = defineCachedHandler(() => new Response("ok"), {
+      maxAge: 10,
+      shouldCache: async (res, event) => {
+        seen.push({ status: res.status, url: new URL(event.req.url).pathname });
+        return true;
+      },
+    });
+
+    await handler(makeEvent(path));
+
+    expect(seen).toContainEqual({ status: 200, url: path });
+  });
+
+  it("shouldCache cannot force-cache a response the built-in checks reject", async () => {
+    let callCount = 0;
+    const path = uniquePath();
+    const handler = defineCachedHandler(
+      () => {
+        callCount++;
+        // 500 is rejected by the built-in status check; shouldCache returning true
+        // must not override that.
+        return new Response("err", { status: 500 });
+      },
+      { maxAge: 10, shouldCache: () => true },
+    );
+
+    await handler(makeEvent(path));
+    await handler(makeEvent(path));
+
+    expect(callCount).toBe(2);
+  });
+
   // Regression: a corrupt/partial stored entry whose `value` lacks a `headers`
   // field must degrade to a cache miss, not throw from validate()'s cache-control
   // check (which runs before the status/body guards).

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1441,6 +1441,34 @@ describe("defineCachedHandler", () => {
     expect(callCount).toBe(2);
   });
 
+  it("fails closed (does not cache, does not throw) when shouldCache throws", async () => {
+    let callCount = 0;
+    const onError = vi.fn();
+    const path = uniquePath();
+    const handler = defineCachedHandler(
+      () => {
+        callCount++;
+        return new Response("ok");
+      },
+      {
+        maxAge: 10,
+        onError,
+        shouldCache: () => {
+          throw new Error("boom");
+        },
+      },
+    );
+
+    const r1 = (await handler(makeEvent(path))) as Response;
+    const r2 = (await handler(makeEvent(path))) as Response;
+
+    // The request still succeeds; the response is just never cached.
+    expect(await r1.text()).toBe("ok");
+    expect(await r2.text()).toBe("ok");
+    expect(callCount).toBe(2);
+    expect(onError).toHaveBeenCalled();
+  });
+
   // Regression: a corrupt/partial stored entry whose `value` lacks a `headers`
   // field must degrade to a cache miss, not throw from validate()'s cache-control
   // check (which runs before the status/body guards).

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1406,20 +1406,20 @@ describe("defineCachedHandler", () => {
     expect(r2.headers.get("x-cache")).toBe("HIT");
   });
 
-  it("shouldCache receives the response entry and event, and supports async", async () => {
-    const seen: Array<{ status: number; url: string }> = [];
+  it("shouldCache receives the response entry and supports async", async () => {
+    const seen: Array<{ status: number; body: string | undefined }> = [];
     const path = uniquePath();
     const handler = defineCachedHandler(() => new Response("ok"), {
       maxAge: 10,
-      shouldCache: async (res, event) => {
-        seen.push({ status: res.status, url: new URL(event.req.url).pathname });
+      shouldCache: async (res) => {
+        seen.push({ status: res.status, body: res.body });
         return true;
       },
     });
 
     await handler(makeEvent(path));
 
-    expect(seen).toContainEqual({ status: 200, url: path });
+    expect(seen).toContainEqual({ status: 200, body: "ok" });
   });
 
   it("shouldCache cannot force-cache a response the built-in checks reject", async () => {


### PR DESCRIPTION
Closes #48.

## Problem

`defineCachedHandler` uses hardcoded response validation that callers can't extend (the `validate`/`transform` options are `Omit`-ted from `CachedEventHandlerOptions`). In particular, `3xx` redirect responses pass the built-in checks (which only reject `status >= 400`) and get cached — combined with SWR headers this can create redirect loops.

## Solution

Add an **additive** `shouldCache` hook to `CachedEventHandlerOptions`:

```ts
shouldCache?: (entry: ResponseCacheEntry, event: E) => boolean | Promise<boolean>
```

- Runs *after* and is **ANDed with** the built-in validation (status, `no-store`/`private`, body, `etag`/`last-modified`).
- Can only *narrow* what gets cached — it cannot force-cache a response the built-in checks reject, so the load-bearing `_forbidsSharedCaching` and error-status guards stay intact.
- May be async; receives the serialized `ResponseCacheEntry` and the originating event.

```ts
const handler = defineCachedHandler(myHandler, {
  maxAge: 60,
  // Keep 3xx redirects out of the cache
  shouldCache: (res) => res.status < 300 || res.status >= 400,
});
```

Implemented by wiring the hook into the internal `validate` (which already receives the call args, so the event is available), keeping the library standalone.

## Changes

- `src/types.ts` — add documented `shouldCache` option to `CachedEventHandlerOptions`.
- `src/http.ts` — AND `shouldCache` into the internal `validate` after the built-in checks.
- `README.md` — new "Custom cache eligibility" subsection.
- `test/index.test.ts` — 4 tests: rejects (redirect), accepts (hit), receives entry+event & async, and cannot force-cache a rejected `5xx`.

## Verification

`pnpm lint`, `pnpm typecheck`, and `pnpm vitest run test/` (138 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional cache-control hook for cached HTTP handlers, letting you further decide whether a response should be stored.
  * The hook supports async checks and receives both the response data and the request context.

* **Bug Fixes**
  * Improved cache validation so built-in safety rules still take priority.
  * Responses rejected by the built-in rules will continue to bypass caching, even if the custom hook allows them.

* **Documentation**
  * Updated the cache handler docs with examples and details on when responses are eligible for caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->