### PR TITLE
feat(http): emit `Vary` response header for `varies`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Never touch contents inside `<!-- automd -->` in README.md. They are auto genera
 - Auto-generates cache keys from URL path + variable headers
 - Handles `304 Not Modified` via `if-none-match`/`if-modified-since`
 - Sets `cache-control`, `etag`, `last-modified` headers — but never clobbers an explicit `cache-control` set by the handler (SWR/`s-maxage`/`max-age` directives are only synthesized when the handler didn't set one)
+- Emits a `Vary` response header from `opts.varies` (the same header names used for the cache key), merging with any `Vary` the handler already set (case-insensitive dedup, wildcard `*` left untouched) so downstream caches store per-variant
 - Honors explicit `Cache-Control: no-store` / `private` on the response — those are never cached (rejected in `validate`), though still returned to the caller. This only governs storage: concurrent requests are still coalesced by cache key, so per-user responses must be keyed correctly (e.g. via `varies`)
 - Filters non-variable headers before calling the handler (for consistent cache keys)
 - Framework integration hooks on `CachedEventHandlerOptions`:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const handler = defineCachedHandler(
     maxAge: 300, // Cache for 5 minutes
     swr: true,
     staleMaxAge: 600,
-    varies: ["accept-language"], // Vary cache by these headers
+    varies: ["accept-language"], // Vary cache key by these headers (also emitted as `Vary`)
     allowQuery: ["color"], // Vary cache by these query params only
   },
 );

--- a/src/http.ts
+++ b/src/http.ts
@@ -258,12 +258,23 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
         maxAge: opts.maxAge,
       })
     ) {
+      // A 304 must echo the `Vary` (and cache-status) that would have accompanied
+      // the full response, so a shared cache doesn't lose the variant dimension
+      // (RFC 7232 §4.1).
+      const notModifiedHeaders: Record<string, string> = {};
       const statusValue = _statusHeader
         ? (response.headers[_statusHeader] as string | undefined)
         : undefined;
+      if (statusValue !== undefined) {
+        notModifiedHeaders[_statusHeader!] = statusValue;
+      }
+      const varyValue = response.headers.vary as string | undefined;
+      if (varyValue !== undefined) {
+        notModifiedHeaders.vary = varyValue;
+      }
       return _createResponse(null, {
         status: 304,
-        headers: statusValue === undefined ? undefined : { [_statusHeader!]: statusValue },
+        headers: Object.keys(notModifiedHeaders).length > 0 ? notModifiedHeaders : undefined,
       });
     }
 
@@ -301,7 +312,8 @@ function _filterSearch(url: URL, names: string[]): string {
  */
 function _appendVary(headers: Headers, names: string[]): void {
   const existing = headers.get("vary");
-  if (existing?.trim() === "*") {
+  // A `*` token means the response varies on everything — nothing to add.
+  if (existing && existing.split(",").some((part) => part.trim() === "*")) {
     return;
   }
   const seen = new Set<string>();

--- a/src/http.ts
+++ b/src/http.ts
@@ -219,6 +219,15 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
       }
     }
 
+    // Advertise the request headers this response varies on so downstream
+    // caches/CDNs/browsers store a separate variant per value — merging with any
+    // `Vary` the handler already set rather than clobbering it (mirrors the
+    // "preserve if present" behavior of the etag / last-modified / cache-control
+    // synthesis above).
+    if (variableHeaderNames.length > 0) {
+      _appendVary(res.headers, variableHeaderNames);
+    }
+
     const cacheEntry: ResponseCacheEntry = {
       status: res.status,
       statusText: res.statusText,
@@ -283,6 +292,38 @@ function _filterSearch(url: URL, names: string[]): string {
   }
   const query = filtered.toString();
   return query ? `?${query}` : "";
+}
+
+/**
+ * Merges `names` into the response's `Vary` header, preserving any header names the
+ * handler already declared and deduplicating case-insensitively. A wildcard
+ * (`Vary: *`) is left untouched since it already varies on everything.
+ */
+function _appendVary(headers: Headers, names: string[]): void {
+  const existing = headers.get("vary");
+  if (existing?.trim() === "*") {
+    return;
+  }
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  const add = (raw: string) => {
+    const name = raw.trim();
+    const key = name.toLowerCase();
+    if (!name || seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    merged.push(name);
+  };
+  if (existing) {
+    for (const part of existing.split(",")) {
+      add(part);
+    }
+  }
+  for (const name of names) {
+    add(name);
+  }
+  headers.set("vary", merged.join(", "));
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,7 +166,11 @@ export interface CachedEventHandlerOptions<E extends HTTPEvent = HTTPEvent> exte
 > {
   /** When `true`, only handles conditional headers (304 responses) without full response caching. */
   headersOnly?: boolean;
-  /** Request header names that should vary the cache key (e.g., `["accept-language"]`). */
+  /**
+   * Request header names that should vary the cache key (e.g., `["accept-language"]`).
+   * These names are also merged into the response's `Vary` header so downstream
+   * caches/CDNs/browsers store a separate variant per value.
+   */
   varies?: string[] | readonly string[];
 
   /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1571,6 +1571,54 @@ describe("defineCachedHandler", () => {
     expect(await r2.text()).toBe("call-2");
   });
 
+  it("emits a Vary response header for configured varies", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(() => new Response("ok"), {
+      maxAge: 10,
+      varies: ["Accept-Language", "X-Custom"],
+    });
+
+    const res = (await handler(makeEvent(path))) as Response;
+    expect(res.headers.get("vary")).toBe("accept-language, x-custom");
+
+    // Served from cache on the next request with the same variant
+    const cached = (await handler(makeEvent(path))) as Response;
+    expect(cached.headers.get("vary")).toBe("accept-language, x-custom");
+  });
+
+  it("does not emit a Vary header when varies is empty", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(() => new Response("ok"), { maxAge: 10 });
+
+    const res = (await handler(makeEvent(path))) as Response;
+    expect(res.headers.get("vary")).toBe(null);
+  });
+
+  it("merges configured varies into a handler-set Vary without duplicates", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(
+      () =>
+        new Response("ok", {
+          headers: { vary: "User-Agent, Accept-Language" },
+        }),
+      { maxAge: 10, varies: ["accept-language", "x-custom"] },
+    );
+
+    const res = (await handler(makeEvent(path))) as Response;
+    expect(res.headers.get("vary")).toBe("User-Agent, Accept-Language, x-custom");
+  });
+
+  it("leaves a wildcard Vary header untouched", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(() => new Response("ok", { headers: { vary: "*" } }), {
+      maxAge: 10,
+      varies: ["accept-language"],
+    });
+
+    const res = (await handler(makeEvent(path))) as Response;
+    expect(res.headers.get("vary")).toBe("*");
+  });
+
   it("only varies the cache key by allowlisted query params (allowQuery)", async () => {
     let callCount = 0;
     const path = uniquePath();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1619,6 +1619,38 @@ describe("defineCachedHandler", () => {
     expect(res.headers.get("vary")).toBe("*");
   });
 
+  it("leaves a Vary header untouched when `*` appears among other tokens", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(
+      () => new Response("ok", { headers: { vary: "User-Agent, *" } }),
+      { maxAge: 10, varies: ["accept-language"] },
+    );
+
+    const res = (await handler(makeEvent(path))) as Response;
+    expect(res.headers.get("vary")).toBe("User-Agent, *");
+  });
+
+  it("echoes the Vary header on a 304 response", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(() => new Response("ok"), {
+      maxAge: 100,
+      varies: ["accept-language"],
+    });
+
+    const r1 = (await handler(
+      makeEvent(path, { headers: { "accept-language": "en" } }),
+    )) as Response;
+    expect(r1.headers.get("vary")).toBe("accept-language");
+    const etag = r1.headers.get("etag")!;
+
+    const r2 = (await handler(
+      makeEvent(path, { headers: { "accept-language": "en", "if-none-match": etag } }),
+    )) as Response;
+
+    expect(r2.status).toBe(304);
+    expect(r2.headers.get("vary")).toBe("accept-language");
+  });
+
   it("only varies the cache key by allowlisted query params (allowQuery)", async () => {
     let callCount = 0;
     const path = uniquePath();


### PR DESCRIPTION
Addresses part 1 of #49.

## Problem

`opts.varies` already varies the cache **key** (`variableHeaderNames`) and strips those headers before calling the handler, but no `Vary` response header was ever set. Downstream caches/CDNs/browsers had no signal that the response differs by those request headers, so they could serve a wrong variant.

## Change

When `opts.varies` is non-empty, merge the configured header names into the response's `Vary` header before storing the cache entry (so it's served on both misses and hits):

- **Preserves** any `Vary` the handler already set rather than clobbering it — mirroring the existing "don't clobber an explicit header" pattern used for `cache-control`/`etag`/`last-modified`.
- **Deduplicates** case-insensitively (handler's original casing wins for its own entries).
- **Leaves a wildcard** (`Vary: *`) untouched, since it already varies on everything.

Pure addition to `src/http.ts` — keeps the standalone design (no h3/srvx/unstorage dependency, generic `EventHandler<E>`).

## Tests

Added coverage for: emitting `Vary` from `varies` (miss + hit), no header when `varies` is empty, merging into a handler-set `Vary` without duplicates, and preserving a wildcard. All 138 tests pass; typecheck clean.

## Scope

This PR covers **only part 1** (Vary header). Parts 2 (`sendCacheControl` / server-only caching) and 3 (`Set-Cookie` caching guard) from #49 are left for follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)