### PR TITLE
refactor!: disable `swr` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const data = await cachedFetch("https://api.example.com/data");
 const cached = defineCachedFunction(fn, {
   name: "my-fn", // Cache key name (defaults to function name)
   maxAge: 10, // TTL in seconds (default: 1)
-  swr: true, // Stale-while-revalidate (default: true)
+  swr: false, // Stale-while-revalidate (default: false — opt in to serve stale)
   staleMaxAge: 60, // Max seconds to serve stale content
   getMaxAge: (entry) => entry.value?.expires_in, // Per-entry TTL from the resolved value
   base: "/cache", // Base prefix for cache keys (string or string[] for multi-tier)

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -7,7 +7,7 @@ function defaultCacheOptions() {
   return {
     name: "_",
     base: "/cache",
-    swr: true,
+    swr: false,
     maxAge: 1,
   } as const;
 }
@@ -476,13 +476,14 @@ function _remainingTtl(
   if (!entry.mtime || maxAge == null || maxAge <= 0) {
     return undefined;
   }
-  // Mirrors the TTL window used on cache writes (see `get` in defineCachedFunction)
-  const ttlWindow =
-    opts.swr === false
-      ? maxAge
-      : staleMaxAge != null && staleMaxAge >= 0
-        ? maxAge + staleMaxAge
-        : undefined;
+  // Mirrors the TTL window used on cache writes (see `get` in defineCachedFunction).
+  // `!opts.swr` (rather than `=== false`) so an unset `swr` aligns with the SWR-off
+  // default on the standalone `expireCache` path, which doesn't merge defaultCacheOptions.
+  const ttlWindow = !opts.swr
+    ? maxAge
+    : staleMaxAge != null && staleMaxAge >= 0
+      ? maxAge + staleMaxAge
+      : undefined;
   if (ttlWindow === undefined) {
     return undefined;
   }

--- a/src/http.ts
+++ b/src/http.ts
@@ -14,7 +14,7 @@ function defaultCacheOptions() {
   return {
     name: "_",
     base: "/cache",
-    swr: true,
+    swr: false,
     maxAge: 1,
     cacheStatusHeader: true,
   } as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,7 +99,7 @@ export interface CacheOptions<T = any, ArgsT extends unknown[] = any[]> {
   integrity?: any;
   /** Number of seconds to cache the response. Defaults to `1`. */
   maxAge?: number;
-  /** Enable stale-while-revalidate behavior. When `true`, returns stale cache while refreshing in the background. Defaults to `true`. */
+  /** Enable stale-while-revalidate behavior. When `true`, returns stale cache while refreshing in the background. Defaults to `false` (an expired entry is re-resolved in the foreground before returning). */
   swr?: boolean;
   /** Maximum number of seconds a stale entry can be served while revalidating. `0` means stale is never served — once expired, revalidation blocks the request. */
   staleMaxAge?: number;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -95,6 +95,7 @@ describe("cachedFunction", () => {
     let n = 0;
     const fn = defineCachedFunction(() => `v${++n}`, {
       maxAge: 100,
+      swr: true, // opt in — SWR is off by default
       getKey: () => "k",
       transform: (entry) => {
         statuses.push(entry.status);
@@ -1874,8 +1875,9 @@ describe("defineCachedHandler", () => {
 
     const res = (await handler(makeEvent(path))) as Response;
     const cc = res.headers.get("cache-control")!;
-    expect(cc).toContain("s-maxage=60");
-    expect(cc).toContain("stale-while-revalidate");
+    // swr is off by default, so a plain max-age is synthesized (no SWR directives)
+    expect(cc).toContain("max-age=60");
+    expect(cc).not.toContain("stale-while-revalidate");
   });
 
   it("works with generic event type", async () => {
@@ -1900,17 +1902,17 @@ describe("defineCachedHandler", () => {
     expect(receivedCustom).toBe("test-value");
   });
 
-  // Regression: issue #4 — passing partial opts (e.g. only maxAge) should inherit swr default
+  // Regression: issue #4 — passing partial opts (e.g. only maxAge) should still merge defaults
   it("inherits swr default when only maxAge is provided", async () => {
     const path = uniquePath();
     const handler = defineCachedHandler(() => new Response("ok"), { maxAge: 30 });
 
     const res = (await handler(makeEvent(path))) as Response;
     const cc = res.headers.get("cache-control")!;
-    // swr should default to true, so we get s-maxage (not max-age)
-    expect(cc).toContain("s-maxage=30");
-    expect(cc).toContain("stale-while-revalidate");
-    expect(cc).not.toContain("max-age=30");
+    // swr defaults to false, so we get a plain max-age (no SWR directives)
+    expect(cc).toContain("max-age=30");
+    expect(cc).not.toContain("s-maxage=30");
+    expect(cc).not.toContain("stale-while-revalidate");
   });
 
   // Regression: issue #5 — handler returning undefined etag/last-modified should invalidate cache
@@ -1993,7 +1995,7 @@ describe("resolveCacheKeys", () => {
     await fn();
 
     const expectedKeys = await resolveCacheKeys({ options: opts });
-    expect(setSpy).toHaveBeenCalledWith(expectedKeys[0], expect.any(Object), undefined);
+    expect(setSpy).toHaveBeenCalledWith(expectedKeys[0], expect.any(Object), { ttl: 10 });
   });
 
   it("matches .resolveKeys on the cached function", async () => {


### PR DESCRIPTION
## Summary

Disables stale-while-revalidate (`swr`) by default in both `defineCachedFunction` and `defineCachedHandler`. Previously it defaulted to `true`.

Closes #51.

## Why (breaking change)

`swr: true` by default meant **a stale — and potentially invalid — value could be served without any opt-in**, which contradicts the project's stated goal of keeping SWR semantics explicit. This was pushed back on in the upstream Nitro project too (nitrojs/nitro#1950).

Concretely, with the old default:

- An expired entry with no `staleMaxAge` set **lived until manually evicted** and was served stale *indefinitely* while revalidating in the background.
- Stacking caching layers (e.g. a cached route calling a cached utility) could **silently double the effective invalidation window**.
- Developers often didn't realize their functions were serving stale data at all.

With `swr: false` as the default, an expired entry is **re-resolved in the foreground before returning** — predictable TTL caching. Serving stale is now an explicit opt-in via `swr: true` (typically paired with `staleMaxAge`).

## Changes

- `defaultCacheOptions()` → `swr: false` in `src/cache.ts` and `src/http.ts`
- Updated JSDoc (`src/types.ts`) and README to document the new default
- Small hardening in `_remainingTtl` (`!opts.swr` instead of `=== false`) so an unset `swr` on the standalone `expireCache` path aligns with the SWR-off default (that path doesn't merge `defaultCacheOptions`)
- Updated tests that relied on the old implicit default; the SWR-on paths are still covered by tests that now opt in explicitly

## Behavior notes for reviewers

- `defineCachedHandler` now synthesizes `Cache-Control: max-age=<maxAge>` by default instead of `s-maxage=<maxAge>, stale-while-revalidate`. This directly removes the CDN cache-stacking hazard, but also means the default is now cacheable by browsers (`max-age`) rather than shared-cache-only (`s-maxage`). If shared-cache-only is preferred for the default, the non-SWR branch in `http.ts` could emit `s-maxage` instead — happy to adjust.
- The change was reviewed by a subagent: `false` (vs removing the key / `undefined`) keeps every strict `opts.swr === false` branch correct, all 134 tests pass, and typecheck is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)