### PR TITLE
fix(http): derive custom cache key uniqueness from a hash

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -102,7 +102,13 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
       // Custom user-defined key
       const customKey = await opts.getKey?.(event as E);
       if (customKey) {
-        return escapeKey(customKey);
+        const _key = escapeKey(customKey);
+        // If escaping was a no-op the key is already storage-safe and can't collide,
+        // so keep it as-is. Otherwise escaping is lossy (distinct keys can collapse to
+        // the same segment), so append a hash of the raw key to keep them distinct.
+        // The `.` separator only appears in the hashed form, so an escaped-clean key
+        // (pure `\w`, never contains `.`) and a hashed key can never overlap.
+        return _key === customKey ? _key : `${_key.slice(0, 64)}.${hash(customKey)}`;
       }
       // Auto-generated key
       const _url = event.url ?? new URL(event.req.url);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1688,6 +1688,34 @@ describe("defineCachedHandler", () => {
     expect(callCount).toBe(1);
   });
 
+  it.each([
+    // Both strip to `user1`, so only the appended key hash keeps them apart.
+    ["user:1", "user1:"],
+    // `foo:bar` strips to `foobar` and gets hashed; `foo_bar` is already clean and
+    // stays as-is — the `.` in the hashed form keeps their key spaces disjoint.
+    ["foo:bar", "foo_bar"],
+  ])("does not collide distinct custom keys (%s vs %s)", async (keyA, keyB) => {
+    let id = keyA;
+    let callCount = 0;
+    const handler = defineCachedHandler(
+      () => {
+        callCount++;
+        return new Response(id);
+      },
+      { maxAge: 10, getKey: () => id },
+    );
+
+    id = keyA;
+    const a = (await handler(makeEvent("/x"))) as Response;
+    id = keyB;
+    const b = (await handler(makeEvent("/x"))) as Response;
+
+    // If the keys collide, `b` wrongly hits `a`'s entry and returns keyA.
+    expect(await a.text()).toBe(keyA);
+    expect(await b.text()).toBe(keyB);
+    expect(callCount).toBe(2);
+  });
+
   it("filters variable headers from handler request", async () => {
     let receivedHeaders: string | null = null;
     const path = uniquePath();


### PR DESCRIPTION
## Problem

Closes #54.

`escapeKey` in `src/http.ts` strips every non-word (`\W`) character from cache key segments:

```js
return String(key).replace(/\W/g, "");
```

Delimiters separating sub-keys are removed entirely, so structurally different custom `getKey` values collapse into the **same** storage key:

- `getKey: () => "1234:56"` → `"123456"`
- `getKey: () => "12:3456"` → `"123456"`

For a per-identity key like `getKey: () => `user:${id}``, `user:1` + suffix `2` collides with `user:12` — a cross-tenant cache collision.

## Fix

Custom keys are now derived in three steps:

1. Escape the raw key.
2. If escaping was a **no-op**, the key is already storage-safe and injective → return it as-is (stays clean and readable).
3. Otherwise escaping is **lossy**, so append `.${hash(rawKey)}` to guarantee uniqueness.

```js
const _key = escapeKey(customKey);
return _key === customKey ? _key : `${_key.slice(0, 64)}.${hash(customKey)}`;
```

**Why this is collision-free:** an un-escaped key is pure `[A-Za-z0-9_]`, so it never contains a `.`; the hashed form always does. The two output spaces are therefore disjoint — clean keys are injective by identity, and lossy keys are disambiguated by `hash(rawKey)`. This mirrors the existing auto-generated `_pathname.${hash(_path)}` key.

`escapeKey` itself is left unchanged: because uniqueness now comes from the hash rather than the escape function, there's no need to switch `\W` removal to a placeholder — the escaped text is only a readable label.

## Sanity check — which sites needed it?

`escapeKey` is used at three sites; only the custom-key site lacked a uniqueness backstop:

| Site | Backstop | Needed fix? |
|------|----------|-------------|
| Custom key (`http.ts:105`) | none — was the raw key segment | **Yes** → escape, hash only when lossy |
| Path prefix (`http.ts:114`) | already `label.${hash(_path)}` | No |
| Header name (`http.ts:121`) | already `label.${hash(value)}` | No |

## Verification

- Parametrized regression test covering `user:1`/`user1:` (both strip to `user1`, hash disambiguates) and `foo:bar`/`foo_bar` (clean-vs-hashed key spaces stay disjoint).
- Full suite: 136 passed. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)