### PR TITLE
fix(http): respect user-supplied `shouldBypassCache` (#50)

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -61,7 +61,9 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
 
   // Non-GET/HEAD requests skip the cache entirely. Shared between the
   // `shouldBypassCache` option and the resolver so the request-narrowing
-  // step below can't disagree with the bypass decision.
+  // step below can't disagree with the bypass decision. This is the built-in
+  // method check only — a caller's `opts.shouldBypassCache` is composed on top
+  // of it in `_opts` below, never in place of it.
   const _shouldBypassCache = (event: HTTPEvent) =>
     event.req.method !== "GET" && event.req.method !== "HEAD";
 
@@ -114,7 +116,16 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
           };
         }
       : undefined,
-    shouldBypassCache: _shouldBypassCache,
+    // Compose the built-in non-GET/HEAD bypass with the caller's opt-in check
+    // instead of clobbering it: bypass when either says so. A bare `...opts`
+    // spread already carried `opts.shouldBypassCache`, but assigning the
+    // built-in here used to silently discard it (issue #50).
+    shouldBypassCache: async (event: HTTPEvent) => {
+      if (_shouldBypassCache(event)) {
+        return true;
+      }
+      return (await opts.shouldBypassCache?.(event as E)) === true;
+    },
     getKey: async (event: HTTPEvent) => {
       // Custom user-defined key
       const customKey = await opts.getKey?.(event as E);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1270,6 +1270,58 @@ describe("defineCachedHandler", () => {
     expect(callCount).toBe(1);
   });
 
+  it("honors a user-supplied shouldBypassCache (issue #50)", async () => {
+    let callCount = 0;
+    const path = uniquePath();
+    const handler = defineCachedHandler(
+      () => {
+        callCount++;
+        return new Response("ok");
+      },
+      {
+        maxAge: 10,
+        // Bypass whenever the request carries a `?bypass` query param.
+        shouldBypassCache: (event) => new URL(event.req.url).searchParams.has("bypass"),
+      },
+    );
+
+    // GET without the flag caches as usual.
+    await handler(makeEvent(path));
+    await handler(makeEvent(path));
+    expect(callCount).toBe(1);
+
+    // GET with the flag must bypass the cache and reach the handler every time.
+    await handler(makeEvent(`${path}?bypass`));
+    await handler(makeEvent(`${path}?bypass`));
+    expect(callCount).toBe(3);
+  });
+
+  it("composes the built-in method bypass with a user shouldBypassCache", async () => {
+    let callCount = 0;
+    const path = uniquePath();
+    const handler = defineCachedHandler(
+      () => {
+        callCount++;
+        return new Response("ok");
+      },
+      {
+        maxAge: 10,
+        // User check only bypasses on a header; non-GET/HEAD must still bypass
+        // via the built-in method check even though this returns false for them.
+        shouldBypassCache: (event) => event.req.headers.get("x-bypass") === "1",
+      },
+    );
+
+    // POST still bypasses (built-in method check), user check returns false.
+    await handler(makeEvent(path, { method: "POST" }));
+    await handler(makeEvent(path, { method: "POST" }));
+    expect(callCount).toBe(2);
+
+    // GET with the user flag bypasses too.
+    await handler(makeEvent(path, { headers: { "x-bypass": "1" } }));
+    expect(callCount).toBe(3);
+  });
+
   it("sets cache-control header with SWR and staleMaxAge", async () => {
     const path = uniquePath();
     const handler = defineCachedHandler(() => new Response("ok"), {


### PR DESCRIPTION
## Problem

Fixes #50 (item 1: `shouldBypassCache` silently discarded).

`defineCachedHandler` spreads the caller's `opts` — including their `shouldBypassCache` — into `_opts`, but then immediately reassigns `shouldBypassCache` to the built-in non-GET/HEAD method check:

```ts
const _opts = {
  ...opts,                          // caller's shouldBypassCache here
  shouldBypassCache: _shouldBypassCache, // ...then clobbered
};
```

So any user-provided `shouldBypassCache` on a cached handler was silently ignored.

## Fix

Compose the two checks instead of replacing: bypass the cache when **either** the built-in method check **or** the caller's `shouldBypassCache` returns `true`.

The internal `_shouldBypassCache` (method-only) is still used for the resolver's request-narrowing step, which only runs on cacheable (non-bypassed) calls — so that path is unchanged.

## Tests

Two new tests under `defineCachedHandler`:
- `honors a user-supplied shouldBypassCache (issue #50)` — a `?bypass` query flag bypasses caching while plain GETs still cache. Verified to **fail before** the fix and **pass after**.
- `composes the built-in method bypass with a user shouldBypassCache` — POST still bypasses via the built-in method check even when the user callback returns `false`.

All 158 tests pass; typecheck clean.

> Note: issue #50 also raises a docs concern about `allowQuery` / cache-key mismatch on invalidation triggers (item 2). That's a separate, non-code concern and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)