### PR TITLE
feat(http): support binary response bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ Never touch contents inside `<!-- automd -->` in README.md. They are auto genera
 ### HTTP handler caching (`http.ts`)
 
 - `defineCachedHandler<E extends HTTPEvent>(handler, opts)` — wraps an `EventHandler` with response caching (generic over event type)
-- Split along the `serialize` seam (built on `cache.ts`'s `cachedFunction<Response>`): the **resolver** narrows the request and returns the handler's live `Response`; the internal **`serialize`** hook consumes the body (`res.text()`), synthesizes `etag`/`last-modified`/`cache-control`/`Vary`, builds the stored `ResponseCacheEntry`, and sets the `_blockSetCookie` flag; **`transform`** reconstructs the servable shape and injects the cache-status header on read. `serialize`/`validate`/`transform` are `Omit`ted from the user-facing `CachedEventHandlerOptions` so internal use doesn't collide
+- Split along the `serialize` seam (built on `cache.ts`'s `cachedFunction<Response>`): the **resolver** narrows the request and returns the handler's live `Response`; the internal **`serialize`** hook consumes the body (`res.arrayBuffer()`), synthesizes `etag`/`last-modified`/`cache-control`/`Vary`, builds the stored `ResponseCacheEntry`, and sets the `_blockSetCookie` flag; **`transform`** reconstructs the servable shape and injects the cache-status header on read. `serialize`/`validate`/`transform` are `Omit`ted from the user-facing `CachedEventHandlerOptions` so internal use doesn't collide
+- Binary responses: `serialize` reads the body as bytes and decides by **byte validity, not content-type** — a valid-UTF-8 body (fatal `TextDecoder` with `ignoreBOM`, lossless roundtrip) is stored verbatim as a string (unchanged text behavior, stable text etags); anything else (images, protobuf/MVT tiles, arbitrary binary) is base64-encoded and flagged `base64: true` on the `ResponseCacheEntry`. Base64 (not a raw `Uint8Array`) so binary bodies survive JSON-serializing storage backends. On read, a `base64` entry is decoded back to a `Uint8Array` before `createResponse`, so the exact bytes replay untouched. `createResponse` therefore receives `string | Uint8Array | null` (widened from `string | null`)
 - Auto-generates cache keys from URL path + variable headers
 - Handles `304 Not Modified` via `if-none-match`/`if-modified-since`
 - Sets `cache-control`, `etag`, `last-modified` headers — but never clobbers an explicit `cache-control` set by the handler (SWR/`s-maxage`/`max-age` directives are only synthesized when the handler didn't set one)
@@ -64,7 +65,7 @@ Never touch contents inside `<!-- automd -->` in README.md. They are auto genera
 - `CacheOptions<T>` — maxAge, swr, staleMaxAge, getMaxAge (dynamic per-entry TTL hook), serialize (write-time hook, mirrors `transform`), base (string | string[] for multi-tier), getKey, validate, transform, etc.
 - `CachedEventHandlerOptions<E>` — extends CacheOptions with headersOnly, varies, toResponse, createResponse, handleCacheHeaders
 - `CacheConditions` — `{ modifiedTime?, maxAge?, etag? }` passed to handleCacheHeaders hook
-- `ResponseCacheEntry` — serialized response (status, statusText, headers, body)
+- `ResponseCacheEntry` — serialized response (status, statusText, headers, body; optional `base64` flag when `body` is base64-encoded binary)
 
 ## Dependencies
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -86,7 +86,9 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
       rawValue instanceof Response ? rawValue : new Response(String(rawValue)));
 
   const _createResponse =
-    opts.createResponse || ((body: string | null, init: ResponseInit) => new Response(body, init));
+    opts.createResponse ||
+    ((body: string | Uint8Array | null, init: ResponseInit) =>
+      new Response(body as BodyInit | null, init));
 
   const _handleCacheHeaders = opts.handleCacheHeaders || _defaultHandleCacheHeaders;
 
@@ -123,15 +125,22 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
       : undefined,
     // Write-side seam: consume the resolved `Response` body, synthesize the cache
     // headers, and build the storable `ResponseCacheEntry`. Runs exactly once per
-    // resolution (shared across deduplicated callers), so `res.text()`'s one-shot
+    // resolution (shared across deduplicated callers), so `res.arrayBuffer()`'s one-shot
     // consumption is safe. Kept out of the resolver so bypassed requests — which never
     // reach `serialize` — get their live `Response` back untouched.
     serialize: async (entry) => {
       const res = entry.value as unknown as Response;
 
-      // Stringified body
-      // TODO: support binary responses
-      const body = await res.text();
+      // Read the body once as raw bytes. A valid-UTF-8 body is stored verbatim as a
+      // string (unchanged behavior, so text etags stay stable); anything else (images,
+      // protobuf/MVT tiles, other binary Buffers) is base64-encoded and flagged, so the
+      // lossy `res.text()` UTF-8 decode can't mangle it and it survives JSON-serializing
+      // storage backends. Valid UTF-8 roundtrips losslessly through the string form, so
+      // the discriminator is byte validity, not the (spoofable/absent) content-type.
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      const text = _decodeUtf8(bytes);
+      const base64 = text === undefined;
+      const body = base64 ? _bytesToBase64(bytes) : text;
 
       if (!res.headers.has("etag")) {
         res.headers.set("etag", `W/"${hash(body)}"`);
@@ -178,6 +187,9 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
         statusText: res.statusText,
         headers: Object.fromEntries(res.headers.entries()),
         body,
+        // Only set for binary bodies — text entries stay flag-free (and byte-identical to
+        // pre-binary-support entries), so `transform`'s `{ ...value }` spread carries it through.
+        ...(base64 && { base64: true }),
       };
 
       // Flag the entry non-storable when it sets a cookie outside the allowlist, read
@@ -410,8 +422,13 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
       });
     }
 
-    // Send Response
-    return _createResponse(response.body ?? null, {
+    // Send Response. Binary bodies were stored base64-encoded; decode them back to raw
+    // bytes so the Response carries the original payload untouched (no UTF-8 mangling).
+    const body =
+      response.base64 && typeof response.body === "string"
+        ? _base64ToBytes(response.body)
+        : (response.body ?? null);
+    return _createResponse(body, {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,
@@ -420,6 +437,40 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
 }
 
 // --- Internal helpers ---
+
+// Fatal decoder so invalid UTF-8 throws (→ binary) instead of substituting replacement
+// characters. `ignoreBOM` keeps a leading BOM in the string so it re-encodes byte-for-byte,
+// preserving the lossless roundtrip that lets valid UTF-8 be stored as a plain string.
+const _utf8Decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+
+/** Decodes bytes as UTF-8, returning `undefined` when they aren't valid UTF-8 (i.e. binary). */
+function _decodeUtf8(bytes: Uint8Array): string | undefined {
+  try {
+    return _utf8Decoder.decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Encodes raw bytes to a base64 string (chunked to stay within `String.fromCharCode` arg limits). */
+function _bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const CHUNK = 0x80_00;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
+/** Decodes a base64 string produced by {@link _bytesToBase64} back to raw bytes. */
+function _base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
 
 function escapeKey(key: string | string[]) {
   return String(key).replace(/\W/g, "");

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,8 +170,19 @@ export interface ResponseCacheEntry {
   statusText: string | undefined;
   /** Response headers as a flat key-value record. */
   headers: Record<string, string>;
-  /** Response body as a string. */
+  /**
+   * Serialized response body. Text bodies are stored verbatim; bodies that aren't
+   * valid UTF-8 (images, protobuf, other binary payloads) are base64-encoded and
+   * flagged with {@link base64}, so they survive both the lossy `res.text()` decode
+   * and JSON-serializing storage backends. Always a string when set.
+   */
   body: string | undefined;
+  /**
+   * When `true`, {@link body} is base64-encoded raw bytes (a non-UTF-8 binary body).
+   * The read path decodes it back to a `Uint8Array` before rebuilding the Response.
+   * Absent for text bodies.
+   */
+  base64?: boolean;
 }
 
 /**
@@ -258,10 +269,12 @@ export interface CachedEventHandlerOptions<E extends HTTPEvent = HTTPEvent> exte
   toResponse?: (value: unknown, event: E) => Response | Promise<Response>;
 
   /**
-   * Create the final cached Response from serialized cache entry data.
+   * Create the final cached Response from serialized cache entry data. The body is a
+   * `string` for text responses, a `Uint8Array` for cached binary responses (decoded
+   * from the stored base64), or `null` for empty/304 responses.
    * Default: `new Response(body, init)`.
    */
-  createResponse?: (body: string | null, init: ResponseInit) => Response;
+  createResponse?: (body: string | Uint8Array | null, init: ResponseInit) => Response;
 
   /**
    * Check conditional request headers (etag/if-modified-since).

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1606,6 +1606,64 @@ describe("defineCachedHandler", () => {
     expect([...out]).toEqual([...bytes]);
   });
 
+  it("caches a binary (non-UTF-8) response body without corruption", async () => {
+    let callCount = 0;
+    const path = uniquePath();
+    // Bytes that are NOT valid UTF-8 (0x80/0xff lead bytes, embedded NUL) — res.text()
+    // would replace them with U+FFFD and mangle the payload irreversibly.
+    const bytes = new Uint8Array([0xff, 0x00, 0x80, 0xfe, 0x01, 0x89, 0x50, 0x4e, 0x47]);
+    const handler = defineCachedHandler(
+      () => {
+        callCount++;
+        return new Response(bytes, { headers: { "content-type": "image/png" } });
+      },
+      { maxAge: 10 },
+    );
+
+    const r1 = (await handler(makeEvent(path))) as Response;
+    const r2 = (await handler(makeEvent(path))) as Response;
+
+    expect([...new Uint8Array(await r1.arrayBuffer())]).toEqual([...bytes]);
+    // The cache HIT reconstructs the exact same bytes from storage.
+    expect([...new Uint8Array(await r2.arrayBuffer())]).toEqual([...bytes]);
+    expect(callCount).toBe(1);
+    expect(r2.headers.get("x-cache")).toBe("HIT");
+    expect(r2.headers.get("content-type")).toBe("image/png");
+  });
+
+  it("stores binary bodies as base64 (survives a JSON-roundtripping storage backend)", async () => {
+    const path = uniquePath();
+    // A storage backend that JSON-serializes entries (like most real ones) — a raw
+    // Uint8Array wouldn't survive this, but a base64 string does.
+    const inner = createMemoryStorage();
+    setStorage({
+      get: (key) => {
+        const raw = inner.get<string>(key) as string | null;
+        return raw == null ? null : JSON.parse(raw);
+      },
+      set: (key, value) => inner.set(key, JSON.stringify(value)),
+    });
+
+    const bytes = new Uint8Array([0xff, 0x00, 0x80, 0xfe]);
+    const handler = defineCachedHandler(() => new Response(bytes), { maxAge: 10 });
+
+    await handler(makeEvent(path));
+    const r2 = (await handler(makeEvent(path))) as Response;
+    expect([...new Uint8Array(await r2.arrayBuffer())]).toEqual([...bytes]);
+    expect(r2.headers.get("x-cache")).toBe("HIT");
+  });
+
+  it("preserves multi-byte UTF-8 text bodies across a cache hit", async () => {
+    const path = uniquePath();
+    const text = "héllo 世界 🚀 — café";
+    const handler = defineCachedHandler(() => new Response(text), { maxAge: 10 });
+
+    await handler(makeEvent(path));
+    const r2 = (await handler(makeEvent(path))) as Response;
+    expect(await r2.text()).toBe(text);
+    expect(r2.headers.get("x-cache")).toBe("HIT");
+  });
+
   it("reaches the handler with the bypassed request body intact", async () => {
     const path = uniquePath();
     let received: string | undefined;
@@ -2637,7 +2695,8 @@ describe("defineCachedHandler", () => {
   it("uses custom createResponse hook", async () => {
     const path = uniquePath();
     const createResponse = vi.fn(
-      (body: string | null, init: ResponseInit) => new Response(body, init),
+      (body: string | Uint8Array | null, init: ResponseInit) =>
+        new Response(body as BodyInit | null, init),
     );
     const handler = defineCachedHandler(() => new Response("ok"), {
       maxAge: 10,
@@ -2652,7 +2711,8 @@ describe("defineCachedHandler", () => {
   it("uses custom createResponse for 304", async () => {
     const path = uniquePath();
     const createResponse = vi.fn(
-      (body: string | null, init: ResponseInit) => new Response(body, init),
+      (body: string | Uint8Array | null, init: ResponseInit) =>
+        new Response(body as BodyInit | null, init),
     );
     const handler = defineCachedHandler(
       () => new Response("body", { headers: { etag: '"test-etag"' } }),


### PR DESCRIPTION
Closes #52.

## Problem

`defineCachedHandler`'s internal `serialize` hook stored response bodies via `await res.text()`, which UTF-8-decodes the bytes. Any non-UTF-8-safe payload — images, protobuf/MVT tiles, arbitrary binary `Buffer`s — was irreversibly mangled by `U+FFFD` replacement-character substitution before being written to storage.

## Approach

Split by **byte validity, not content-type** (which is spoofable and often absent):

- **Write (`serialize`)** — read the body once via `res.arrayBuffer()`, then try a fatal `TextDecoder("utf-8", { ignoreBOM: true })`. Valid UTF-8 roundtrips losslessly, so it's stored verbatim as a string (unchanged text behavior, **stable text etags**). Anything else is base64-encoded and flagged `base64: true` on the `ResponseCacheEntry`.
- **Why base64, not a raw `Uint8Array`** — a typed array doesn't survive JSON-serializing storage backends (redis/unstorage/etc.). Base64 is portable everywhere.
- **Read** — a flagged entry is decoded back to a `Uint8Array` before `createResponse`, so the exact bytes replay untouched.

## Changes

- `src/http.ts` — rewrote the body path in `serialize`; decode-on-read in the final response builder; added `_decodeUtf8` / `_bytesToBase64` / `_base64ToBytes` helpers.
- `src/types.ts` — added `ResponseCacheEntry.base64?: boolean`; widened `createResponse` body param to `string | Uint8Array | null`.
- `test/index.test.ts` — 3 new tests (binary roundtrip through cache, base64 survival across a JSON-serializing storage backend, multi-byte UTF-8 text preserved); updated 2 mock signatures.
- `AGENTS.md` — documented the binary seam.

## Breaking change

A custom `createResponse` hook can now receive a `Uint8Array` (was `string | null`). Binary responses were corrupted before this change, so it's strictly an improvement — flagged for the changelog.

## Verification

All 176 tests pass, typecheck (`tsgo`) and lint (`oxlint`) are clean. Verified end-to-end with a real PNG: bytes roundtrip losslessly on MISS and HIT, etag stays stable, and conditional requests still return `304`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cached handlers now support non-UTF-8 binary response bodies, so binary content can be served from cache without corruption.
  * Cached responses can now be reconstructed from either text or raw bytes, improving compatibility with more response types.

* **Bug Fixes**
  * Preserved multi-byte UTF-8 text correctly when reading responses back from cache.
  * Improved cache handling for empty and non-text responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->