### PR TITLE
feat(http): expose `.expire`/`.invalidate`/`.resolveKeys` on cached handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,20 @@ setStorage(createMemoryStorage({ maxSize: Infinity }));
 
 <!-- automd:docs4ts -->
 
+### `CachedEventHandler`
+
+```ts
+type CachedEventHandler<E extends HTTPEvent = HTTPEvent> = EventHandler<E> &
+```
+
+Cached event handler returned by `defineCachedHandler`.
+
+An [`EventHandler`](#eventhandler) augmented with on-demand revalidation methods forwarded from
+the underlying cached function. Each accepts the [`HTTPEvent`](#httpevent) directly and derives
+the exact storage key the handler caches under, so no manual key reconstruction is needed.
+
+---
+
 ### `cachedFunction`
 
 ```ts
@@ -438,7 +452,9 @@ sets `cache-control`, `etag`, and `last-modified` headers, and handles
 - **`handler`** — The event handler to cache.
 - **`opts`** — Cache and HTTP-specific configuration options.
 
-**Returns:** — A new event handler that serves cached responses when available.
+**Returns:** — A new event handler that serves cached responses when available. The handler
+also exposes `.resolveKeys(event)`, `.invalidate(event)`, and `.expire(event)` for
+on-demand revalidation, keyed exactly as the handler caches (no key reconstruction).
 
 ---
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -4,6 +4,7 @@ import { cachedFunction } from "./cache.ts";
 import type {
   HTTPEvent,
   EventHandler,
+  CachedEventHandler,
   CacheOptions,
   CachedEventHandlerOptions,
   CacheConditions,
@@ -29,12 +30,14 @@ function defaultCacheOptions() {
  *
  * @param handler - The event handler to cache.
  * @param opts - Cache and HTTP-specific configuration options.
- * @returns A new event handler that serves cached responses when available.
+ * @returns A new event handler that serves cached responses when available. The handler
+ *   also exposes `.resolveKeys(event)`, `.invalidate(event)`, and `.expire(event)` for
+ *   on-demand revalidation, keyed exactly as the handler caches (no key reconstruction).
  */
 export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
   handler: EventHandler<E>,
   opts: CachedEventHandlerOptions<E> = {},
-): EventHandler<E> {
+): CachedEventHandler<E> {
   opts = { ...defaultCacheOptions(), ...opts };
 
   // Allowlist of cookie names that may participate in caching. `undefined` means
@@ -378,7 +381,7 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
     return _toResponse(rawValue, event as E);
   }, _opts);
 
-  return async (event) => {
+  const cachedHandler: EventHandler<E> = async (event) => {
     // Headers-only mode
     if (opts.headersOnly) {
       if (_handleCacheHeaders(event, { maxAge: opts.maxAge })) {
@@ -440,6 +443,18 @@ export function defineCachedHandler<E extends HTTPEvent = HTTPEvent>(
       headers: response.headers,
     });
   };
+
+  // Forward the on-demand revalidation methods from the internal cached function so
+  // callers can `.expire(event)` / `.invalidate(event)` / `.resolveKeys(event)` without
+  // reconstructing the auto-generated key (which internal escaping makes error-prone —
+  // issue #71). The internal resolver's args are `[event]`, so these accept the event
+  // directly and derive the exact keys the handler stores under.
+  const _revalidate = cachedHandler as CachedEventHandler<E>;
+  _revalidate.resolveKeys = (event: E) => _cachedHandler.resolveKeys(event);
+  _revalidate.invalidate = (event: E) => _cachedHandler.invalidate(event);
+  _revalidate.expire = (event: E) => _cachedHandler.expire(event);
+
+  return _revalidate;
 }
 
 // --- Internal helpers ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export type {
   HTTPEvent,
   ServerRequest,
   EventHandler,
+  CachedEventHandler,
   CacheEntry,
   CacheStatus,
   CacheOptions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,22 @@ export type EventHandler<E extends HTTPEvent = HTTPEvent> = (
 ) => unknown | Promise<unknown>;
 
 /**
+ * Cached event handler returned by `defineCachedHandler`.
+ *
+ * An {@link EventHandler} augmented with on-demand revalidation methods forwarded from
+ * the underlying cached function. Each accepts the {@link HTTPEvent} directly and derives
+ * the exact storage key the handler caches under, so no manual key reconstruction is needed.
+ */
+export type CachedEventHandler<E extends HTTPEvent = HTTPEvent> = EventHandler<E> & {
+  /** Resolves all storage keys (one per base prefix) the handler would cache the event under. */
+  resolveKeys: (event: E) => Promise<string[]>;
+  /** Invalidates (removes) cached entries for the event across all base prefixes. */
+  invalidate: (event: E) => Promise<void>;
+  /** Marks cached entries for the event as stale across all base prefixes. With SWR, stale values are still served (within `staleMaxAge`) while the next access triggers a background refresh. */
+  expire: (event: E) => Promise<void>;
+};
+
+/**
  * How a cached value was served on a given call.
  *
  * - `"hit"` — a fresh cached value was returned without re-resolving.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2928,6 +2928,73 @@ describe("defineCachedHandler", () => {
     await handler(makeEvent(path));
     expect(callCount).toBe(2);
   });
+
+  it("exposes .resolveKeys(event) matching the auto-generated storage key (#71)", async () => {
+    const path = uniquePath();
+    const handler = defineCachedHandler(() => new Response("ok"), { maxAge: 10 });
+
+    const event = makeEvent(path);
+    // Populate the cache, then read it directly using the resolved key.
+    await handler(event);
+
+    const keys = await handler.resolveKeys(event);
+    expect(keys.length).toBe(1);
+    const stored = await useStorage().get(keys[0]!);
+    expect(stored).toBeTruthy();
+    expect((stored as any).value.body).toBe("ok");
+  });
+
+  it(".invalidate(event) removes the cached entry (#71)", async () => {
+    let callCount = 0;
+    const path = uniquePath();
+    const handler = defineCachedHandler(
+      () => {
+        callCount++;
+        return new Response(`v${callCount}`);
+      },
+      { maxAge: 100 },
+    );
+
+    const r1 = (await handler(makeEvent(path))) as Response;
+    expect(await r1.text()).toBe("v1");
+    // Cache hit — handler not re-invoked.
+    const r2 = (await handler(makeEvent(path))) as Response;
+    expect(await r2.text()).toBe("v1");
+    expect(callCount).toBe(1);
+
+    await handler.invalidate(makeEvent(path));
+    const [key] = await handler.resolveKeys(makeEvent(path));
+    expect(await useStorage().get(key!)).toBeFalsy();
+
+    // Next call re-resolves.
+    const r3 = (await handler(makeEvent(path))) as Response;
+    expect(await r3.text()).toBe("v2");
+    expect(callCount).toBe(2);
+  });
+
+  it(".expire(event) triggers a background refresh under SWR (#71)", async () => {
+    let callCount = 0;
+    const path = uniquePath();
+    const handler = defineCachedHandler(
+      () => {
+        callCount++;
+        return new Response(`v${callCount}`);
+      },
+      { maxAge: 100, swr: true, staleMaxAge: 100 },
+    );
+
+    const r1 = (await handler(makeEvent(path))) as Response;
+    expect(await r1.text()).toBe("v1");
+    expect(callCount).toBe(1);
+
+    await handler.expire(makeEvent(path));
+
+    // Stale value is served while the background refresh runs.
+    const r2 = (await handler(makeEvent(path))) as Response;
+    expect(await r2.text()).toBe("v1");
+    // Background revalidation eventually re-invokes the handler.
+    await vi.waitFor(() => expect(callCount).toBe(2));
+  });
 });
 
 describe("resolveCacheKeys", () => {


### PR DESCRIPTION
Closes #71.

## Problem

The handler returned by `defineCachedHandler` did **not** expose the on-demand revalidation methods that `defineCachedFunction` results have (`.expire()`, `.invalidate()`, `.resolveKeys()`). Callers had to reconstruct cache keys manually with the standalone `invalidateCache()` / `expireCache()` helpers — error-prone, since the handler's auto-generated key (URL path + varies headers, with internal escaping) is hard to reproduce by hand.

## Change

`defineCachedHandler` now forwards the three methods from its internal cached function onto the returned handler. They accept the `HTTPEvent` directly and derive the exact storage key the handler caches under:

```ts
const page = defineCachedHandler(render, { swr: true, maxAge: 60 });

await page.expire(event);     // ISR-style: serve stale once more, refresh in background
await page.invalidate(event); // hard purge: next request blocks on a fresh render
const keys = await page.resolveKeys(event);
```

This matches the API already documented in the README's ISR section, and aligns handler revalidation with the function-based API.

## Details

- New `CachedEventHandler<E>` type (`EventHandler<E>` augmented with the three methods), now the return type of `defineCachedHandler` and exported from the package.
- The forwarded methods reuse the internal resolver's key derivation (args are `[event]`), so no key reconstruction / escaping footgun.
- Tests added covering `.resolveKeys` matching the stored key, `.invalidate` removing the entry, and `.expire` triggering an SWR background refresh.

Typecheck, build, and full test suite (183 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)